### PR TITLE
refactor(ws): make the websocket logic more generic/hookable

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -166,6 +166,10 @@ pub(crate) trait WebsocketServer {
             tokio::select! {
                 biased;
 
+                _ = tokio::signal::ctrl_c() => {
+                    break 'outer;
+                }
+
                 incoming = listener.accept() => {
                     let (stream, addr) = match incoming {
                         Ok(sa) => sa,

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -56,15 +56,6 @@ where
     }
 }
 
-impl IntoCtrlEvent<SocketAddr, String> for crate::plugin::runner::Envelope {
-    fn into_ctrl_event(self) -> CtrlEvent<SocketAddr, String> {
-        CtrlEvent::SendTo {
-            addr: self.0,
-            message: serde_json::to_string(&self.1).unwrap(),
-        }
-    }
-}
-
 impl<A, T> CtrlEvent<A, T>
 where
     T: Into<Message> + Clone,

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -1,5 +1,11 @@
-use std::{collections::HashMap, fmt::Debug, net::SocketAddr, sync::Arc};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fmt;
+use std::hash::Hash;
+use std::io;
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 
+use tokio::net::ToSocketAddrs;
 use tokio::{net::TcpListener, runtime::Handle};
 use tokio::{
     net::TcpStream,
@@ -9,25 +15,32 @@ use tokio::{
 use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
 
 use futures::prelude::*;
-use futures::stream::SplitSink;
+use futures::stream::{SplitSink, SplitStream};
+use xtra::Actor;
+use xtra::Address;
 
 #[derive(Debug)]
-enum CtrlEvent<M: Debug> {
+enum CtrlEvent<A, M>
+where
+    A: Hash + Eq,
+    M: Debug,
+{
     Track {
-        addr: SocketAddr,
+        addr: A,
         sink: SplitSink<WebSocketStream<TcpStream>, Message>,
     },
 
     Forget {
-        addr: SocketAddr,
+        addr: A,
     },
 
     Send(M),
 }
 
-impl<T> CtrlEvent<T>
+impl<A, T> CtrlEvent<A, T>
 where
     T: Into<Message> + Clone + Debug,
+    A: Hash + Eq + Clone,
 {
     async fn recv_from_rx(mut rx: UnboundedReceiver<Self>) {
         let mut peers = HashMap::new();
@@ -36,14 +49,21 @@ where
         while let Some(ev) = rx.recv().await {
             discard.clear();
 
-            let _ = match ev {
-                CtrlEvent::Track { addr, sink } => peers.insert(addr, sink),
-                CtrlEvent::Forget { ref addr } => peers.remove(addr),
+            match ev {
+                CtrlEvent::Track { addr, sink } => {
+                    peers.insert(addr, sink);
+                }
+
+                CtrlEvent::Forget { ref addr } => {
+                    peers.remove(addr);
+                }
+
                 CtrlEvent::Send(body) => {
                     for (addr, sink) in peers.iter_mut() {
                         let result = sink.send(body.clone().into()).await;
 
                         if result.is_err() {
+                            let _ = sink.close().await;
                             discard.push(addr.clone());
                         }
                     }
@@ -59,53 +79,130 @@ where
     }
 }
 
-pub async fn serve<A>(
-    address: A,
-    rt_handle: Handle,
-    mut rx: UnboundedReceiver<String>,
-) -> std::io::Result<()>
-where
-    A: tokio::net::ToSocketAddrs,
-{
-    let listener = TcpListener::bind(address).await?;
+#[async_trait::async_trait]
+pub(crate) trait WebsocketServer {
+    async fn bind<S>(&mut self, address: S) -> io::Result<TcpListener>
+    where
+        S: ToSocketAddrs + Send;
 
-    let (i_tx, i_rx) = unbounded_channel::<CtrlEvent<String>>();
+    async fn on_message(&mut self, addr: SocketAddr, message: Message) {}
 
-    rt_handle.spawn(CtrlEvent::recv_from_rx(i_rx));
+    async fn on_connect(
+        &mut self,
+        addr: SocketAddr,
+        stream: WebSocketStream<TcpStream>,
+    ) -> Result<WebSocketStream<TcpStream>, ()> {
+        Ok(stream)
+    }
 
-    let fut = {
-        let i_tx = i_tx.clone();
+    async fn serve<S, M>(
+        &mut self,
+        address: S,
+        rt_handle: Handle,
+        mut event_rx: UnboundedReceiver<M>,
+    ) -> io::Result<()>
+    where
+        M: Sync + Send + fmt::Debug + Into<Message> + Clone + 'static,
+        S: ToSocketAddrs + Send,
+    {
+        let listener = self.bind(address).await?;
 
-        async move {
-            while let Some(st) = rx.recv().await {
-                let _ = i_tx.send(CtrlEvent::Send(st));
-            }
-        }
-    };
+        let (i_tx, i_rx) = unbounded_channel::<CtrlEvent<SocketAddr, M>>();
 
-    rt_handle.spawn(fut);
+        rt_handle.spawn(CtrlEvent::recv_from_rx(i_rx));
 
-    while let Ok((stream, addr)) = listener.accept().await {
-        let (stream, i_tx) = match tokio_tungstenite::accept_async(stream).await {
-            Ok(stream) => (stream, i_tx.clone()),
-            Err(error) => {
-                // TODO: log WS errors.
-                continue;
+        let forwarder_fut = {
+            let i_tx = i_tx.clone();
+
+            async move {
+                while let Some(st) = event_rx.recv().await {
+                    let _ = i_tx.send(CtrlEvent::Send(st));
+                }
             }
         };
 
-        let (out, mut inc) = stream.split();
+        rt_handle.spawn(forwarder_fut);
 
-        let _ = i_tx.send(CtrlEvent::Track {
-            addr: addr.clone(),
-            sink: out,
-        });
+        let (m_tx, mut m_rx) = unbounded_channel::<(SocketAddr, Message)>();
 
-        rt_handle.spawn(async move {
-            while let Some(Ok(_)) = inc.next().await {} // we don't handle incomming WS messages so just drop'em.
-            i_tx.send(CtrlEvent::Forget { addr })
-        });
+        'outer: loop {
+            tokio::select! {
+                biased;
+
+                incoming = listener.accept() => {
+                    let (stream, addr) = match incoming {
+                        Ok(sa) => sa,
+                        Err(_) => break 'outer,
+                    };
+
+                    let (stream, i_tx) = match tokio_tungstenite::accept_async(stream).await {
+                        Ok(stream) => (stream, i_tx.clone()),
+                        Err(error) => {
+                            // TODO: log WS errors.
+                            continue 'outer;
+                        }
+                    };
+
+                    let (out, mut inc) = match self.on_connect(addr.clone(), stream).await {
+                        Ok(stream) => stream.split(),
+                        Err(_) => continue 'outer,
+                    };
+
+                    let _ = i_tx.send(CtrlEvent::Track {
+                        addr: addr.clone(),
+                        sink: out,
+                    });
+
+                    let m_tx = m_tx.clone();
+
+                    rt_handle.spawn(async move {
+                        while let Some(Ok(message)) = inc.next().await {
+                            if let Err(_) = m_tx.send((addr, message)) {
+                                break;
+                            }
+                        }
+
+                        i_tx.send(CtrlEvent::Forget { addr })
+                    });
+                }
+
+                message = m_rx.recv() => {
+                    let (addr, message) = match message {
+                        Some(p) => p,
+                        None => break 'outer,
+                    };
+
+                    self.on_message(addr, message).await;
+                }
+
+                else => break 'outer,
+            }
+        }
+
+        Ok(())
     }
+}
 
-    Ok(())
+#[async_trait::async_trait]
+impl WebsocketServer for Option<std::net::TcpListener> {
+    async fn bind<S>(&mut self, address: S) -> io::Result<TcpListener>
+    where
+        S: ToSocketAddrs + Send,
+    {
+        TcpListener::try_from(self.take().unwrap())
+    }
+}
+
+pub async fn serve<S, M>(
+    address: S,
+    rt_handle: Handle,
+    mut event_rx: UnboundedReceiver<M>,
+) -> std::io::Result<()>
+where
+    M: Sync + Send + fmt::Debug + Into<Message> + Clone + 'static,
+    S: std::net::ToSocketAddrs
+{
+    let listener = std::net::TcpListener::bind(address)?;
+
+    Some(listener).serve("<already bound>", rt_handle, event_rx).await
 }


### PR DESCRIPTION
Pulls out `websocket::serve` logic into a `WebsocketServer` trait allowing more control over the session flow (necessary for how the early plugins api will work.)