### PR TITLE
Move sidebar dashboard item

### DIFF
--- a/ui/src/Components/Sidebar/General.jsx
+++ b/ui/src/Components/Sidebar/General.jsx
@@ -1,14 +1,19 @@
 import React from "react";
 import { NavLink } from "react-router-dom";
 
+import HomeIcon from "../../assets/Icons/Home";
 import WrenchIcon from "../../assets/Icons/Wrench";
 
-const Account = () => (
-  <section className="your-account">
+const General = () => (
+  <section className="yourAccount">
     <header>
-      <h4>Account</h4>
+      <h4>General</h4>
     </header>
     <div className="list">
+      <NavLink className="item" to="/" exact>
+        <HomeIcon/>
+        <p>Dashboard</p>
+      </NavLink>
       <NavLink to="/preferences" className="item">
         <WrenchIcon/>
         <p>Preferences</p>
@@ -17,4 +22,4 @@ const Account = () => (
   </section>
 );
 
-export default Account;
+export default General;

--- a/ui/src/Components/Sidebar/Index.jsx
+++ b/ui/src/Components/Sidebar/Index.jsx
@@ -1,14 +1,15 @@
 import { useEffect, useRef } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { fetchUser } from "../../actions/user.js";
 import { fetchUserSettings } from "../../actions/settings.js";
+import { fetchLibraries } from "../../actions/library.js";
 
 import Profile from "./Profile/Index";
 import Search from "./Search";
 import Libraries from "./Libraries";
 import Toggle from "./Toggle";
-import Account from "./Account";
+import General from "./General";
 
 import "./Index.scss";
 
@@ -16,7 +17,12 @@ function Sidebar() {
   const dispatch = useDispatch();
   const divContainer = useRef(null);
 
+  const libraries = useSelector(store => (
+    store.library.fetch_libraries
+  ));
+
   useEffect(() => {
+    dispatch(fetchLibraries());
     dispatch(fetchUser());
     dispatch(fetchUserSettings());
   }, [dispatch]);
@@ -29,8 +35,10 @@ function Sidebar() {
           <div className="separator"/>
           <Search/>
         </section>
-        <Libraries/>
-        <Account/>
+        {libraries.items.length > 0 && (
+          <Libraries/>
+        )}
+        <General/>
       </div>
       <Toggle sidebar={divContainer}/>
     </nav>

--- a/ui/src/Components/Sidebar/Index.scss
+++ b/ui/src/Components/Sidebar/Index.scss
@@ -42,6 +42,10 @@
       margin-bottom: .5em;
     }
 
+    &.yourAccount {
+      margin: 2em 0;
+    }
+
     &.libraries {
       margin: 2em 0;
 

--- a/ui/src/Components/Sidebar/Libraries.jsx
+++ b/ui/src/Components/Sidebar/Libraries.jsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect } from "react";
-import { NavLink } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
+
 import NewLibraryModal from "../../Modals/NewLibrary/Index";
+import { handleWsNewLibrary, handleWsDelLibrary, wsScanStart, wsScanStop } from "../../actions/library.js";
 
-import { fetchLibraries, handleWsNewLibrary, handleWsDelLibrary, wsScanStart, wsScanStop } from "../../actions/library.js";
-
-import HomeIcon from "../../assets/Icons/Home";
 import Library from "./Library";
 
 function Libraries() {
@@ -43,11 +41,7 @@ function Libraries() {
     return () => ws.conn.removeEventListener("message", handleWS);
   }, [handleWS, ws.conn]);
 
-  useEffect(() => {
-    dispatch(fetchLibraries());
-  }, [dispatch]);
-
-  let libs;
+  let libs = [];
 
   const { fetched, error, items } = libraries;
 
@@ -69,10 +63,6 @@ function Libraries() {
         </NewLibraryModal>
       </header>
       <div className="list">
-        <NavLink className="item" to="/" exact>
-          <HomeIcon/>
-          <p>Dashboard</p>
-        </NavLink>
         {libs}
       </div>
     </section>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44278658/127785630-696ab988-b529-4cec-a56e-186bcfcd84ac.png)

Decision for putting it in the bottom: looks bad when it's above and not in active state. Plus, preferences doesn't look too lonely since logout button has been moved inside it.

I guess also, priorities, at the end of the day, libraries I'd say take priority over dashboard which is the first thing people visit anyway by default.