### PR TITLE
Refactor image loading

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -29,10 +29,13 @@
         --quinaryColor: #5a5a5a;
         --senaryColor: #6a6a6a;
         --septenaryColor: #7a7a7a;
-        --bannerPrimaryColor: #3a3a3a;
+        --bannerPrimaryColor: #2a2a2a;
+        --bannerSecondaryColor: #3a3a3a;
         --bannerPrimaryTextColor: #fff;
         --bannerSecondaryTextColor: #ddd;
         --bannerTertiaryTextColor: #ccc;
+        --bannerBottomBorderColor: #3a3a3a;
+        --bannerOverlayShadow: #1a1a1add;
       }
     </style>
   </body>

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -61,14 +61,16 @@ const routes = (
 );
 
 const App = () => (
-  <WS>
+  <>
     <ThemeController/>
     <FaviconController/>
-    <BrowserRouter>
-      {routes}
-    </BrowserRouter>
-    <Notifications/>
-  </WS>
+    <WS>
+      <BrowserRouter>
+        {routes}
+      </BrowserRouter>
+      <Notifications/>
+    </WS>
+  </>
 );
 
 export default App;

--- a/ui/src/Components/Banners/Banner.jsx
+++ b/ui/src/Components/Banners/Banner.jsx
@@ -63,10 +63,7 @@ function Banner(props) {
 
     return (
       <div className="banner">
-        <Image
-          src={backdrop}
-          hideAnimationName="onHideBannerImage"
-        />
+        <Image src={backdrop}/>
         <div className="extras">
           <Link to={`/search?year=${year}`}>{year}</Link>
           {genres.length > 0 && (

--- a/ui/src/Components/Banners/Banner.jsx
+++ b/ui/src/Components/Banners/Banner.jsx
@@ -11,7 +11,10 @@ import CircleIcon from "../../assets/Icons/Circle";
 import "./Banner.scss";
 
 function Banner(props) {
-  const banners = useSelector(store => store.banner);
+  const { banners, libraries } = useSelector(store => ({
+    banners: store.banner,
+    libraries: store.library.fetch_libraries
+  }));
 
   // FETCH_BANNERS_FETCHING or FETCH_BANNERS_ERROR
   if (banners.fetching || (banners.fetched && banners.error)) {
@@ -24,6 +27,23 @@ function Banner(props) {
 
   // FETCH_BANNERS_FETCHED
   if (banners.fetched && !banners.error) {
+    if (!props.data && libraries.fetched && libraries.items.length > 0) {
+      return (
+        <div className="banner">
+          <div className="placeholder">
+            <h2>Your libraries are empty</h2>
+            <p>
+              Populate the folders they are pointing to with
+              media or add another library with existing media
+            </p>
+            <NewLibraryModal>
+              <button>Add another library</button>
+            </NewLibraryModal>
+          </div>
+        </div>
+      );
+    }
+
     if (!props.data) {
       return (
         <div className="banner">

--- a/ui/src/Components/Banners/Banner.scss
+++ b/ui/src/Components/Banners/Banner.scss
@@ -12,7 +12,7 @@
     "info"
     "progressbar";
   transition: padding .3s ease-in-out;
-  border-bottom: 4px solid #2a2a2a;
+  border-bottom: 4px solid var(--bannerBottomBorderColor);
 
   .placeholder {
     z-index: 1;
@@ -28,7 +28,6 @@
     border-radius: 0;
     text-align: center;
     background: var(--bannerPrimaryColor);
-    border-bottom: 4px solid #3a3a3a;
 
     h2 {
       font-family: "Roboto Bold", Arial;
@@ -60,7 +59,7 @@
     }
   }
 
-  .image-wrapper {
+  .imageWrapper {
     z-index: -1;
     top: 0;
     right: 0;
@@ -68,35 +67,44 @@
     bottom: 0;
     position: absolute;
     overflow: hidden;
-    animation: onActiveBannerImage .3s ease-in-out;
 
-    img {
-      mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
-      transition: object-position .3s ease-in-out;
-      object-fit: cover;
+    .placeholder {
+      background: var(--bannerPrimaryColor);
+    }
+
+    .imageLoad {
       height: 100%;
-      width: 100%;
-    }
+      animation: onHideBannerImage 0s ease-in-out forwards;
 
-    // overlay shadow
-    &::after {
-      content: "";
-      position: absolute;
-      left: 0;
-      height: 100%;
-      width: 100%;
-      background: #1a1a1add;
-      transition: background .2s ease-in-out;
-    }
+      &.show-true {
+        animation: onActiveBannerImage 400ms ease-in-out forwards;
+      }
 
-    &.show-true {
-      animation: onActiveBannerImage .3s ease-in-out forwards;
-    }
+      &.show-false {
+        animation: onHideBannerImage 300ms ease-in-out forwards;
+      }
 
-    &.show-false {
-      animation: onHideBannerImage .3s ease-in-out forwards;
+      img {
+        mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
+        transition: object-position .3s ease-in-out;
+        object-fit: cover;
+        height: 100%;
+        width: 100%;
+      }
+
+      // overlay shadow
+      &::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        background: var(--bannerOverlayShadow);
+        transition: background .2s ease-in-out;
+      }
     }
   }
+
 
   // year + genre
   .extras {
@@ -149,6 +157,50 @@
 }
 
 /*
+    * == KEYFRAMES ==
+*/
+
+@keyframes onActiveBannerImage {
+  0% {
+    opacity: 0;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes onHideBannerImage {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.05);
+  }
+}
+
+@keyframes onHideBanner {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes onActiveBanner {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/*
     * == MEDIA QUERIES ==
 */
 
@@ -184,7 +236,7 @@
       "genres ."
       "info progressbar";
 
-    .image-wrapper {
+    .imageWrapper {
       &::after {
         background: #1a1a1abb;
       }

--- a/ui/src/Components/Banners/Crumbs.scss
+++ b/ui/src/Components/Banners/Crumbs.scss
@@ -12,7 +12,7 @@
     height: 15px;
     width: 15px;
     border-radius: 50%;
-    border: solid 3px #fff;
+    border: solid 3px var(--bannerPrimaryTextColor);
     transition: transform .1s ease-in-out;
     cursor: pointer;
 
@@ -22,7 +22,7 @@
 
     &.active {
       animation: crumbActive .5s ease-out;
-      background: #fff;
+      background: var(--bannerPrimaryTextColor);
     }
   }
 }

--- a/ui/src/Components/Banners/Image.jsx
+++ b/ui/src/Components/Banners/Image.jsx
@@ -1,62 +1,23 @@
-import { useState, useEffect, useCallback } from "react";
+import ImageLoad from "../ImageLoad";
 
-function BannerImage(props) {
-  const [currentSrc, setCurrentSrc] = useState();
-  const [show, setShow] = useState(false);
+const BannerImage = (props) => (
+  <div className="imageWrapper">
+    <ImageLoad src={props.src} triggerAnimation="onHideBannerImage">
+      {(imageSrc, loaded, error) => {
+        if (!error) return (
+          <img
+            src={imageSrc}
+            key={imageSrc}
+            aria-label="banner"
+          />
+        );
 
-  const [loaded, setLoaded] = useState(false);
-  const [error, setErr] = useState(false);
-
-  useEffect(() => {
-    const propsSrcFile = props.src?.substring(props.src.lastIndexOf("/") + 1);
-    const currentSrcFile = currentSrc?.substring(currentSrc.lastIndexOf("/") + 1);
-
-    if (propsSrcFile !== currentSrcFile) {
-      setShow(false);
-      setLoaded(false);
-    }
-  }, [currentSrc, props.src]);
-
-  const swapSrc = useCallback(e => {
-    if (e.animationName !== props.hideAnimationName) return;
-
-    setErr(false);
-
-    if (props.src !== currentSrc) {
-      const img = new Image();
-
-      img.onload = (e) => {
-        setLoaded(true);
-        setShow(true);
-        setCurrentSrc(img.src);
-      };
-
-      img.onerror = () => {
-        setLoaded(true);
-        setShow(true);
-        setErr(true);
-      };
-
-      img.src = new RegExp("/^(?:/|[a-z]+://)/").test(props.src)
-        ? props.src : `/${props.src}`;
-    }
-  }, [currentSrc, props.hideAnimationName, props.src]);
-
-  return (
-    <div
-      className={`image-wrapper show-${show && loaded}`}
-      onAnimationEnd={swapSrc}
-    >
-      {!error && (
-        <img
-          src={currentSrc}
-          key={currentSrc}
-          aria-label="banner"
-        />
-      )}
-      {error && <div className="placeholder"/>}
-    </div>
-  );
-}
+        if (error) return (
+          <div className="placeholder"/>
+        );
+      }}
+    </ImageLoad>
+  </div>
+);
 
 export default BannerImage;

--- a/ui/src/Components/Banners/Index.scss
+++ b/ui/src/Components/Banners/Index.scss
@@ -1,7 +1,7 @@
 .banner-wrapper {
   position: relative;
   z-index: 0;
-  background: #1a1a1a;
+  background: var(--bannerPrimaryColor);
   overflow: hidden;
   animation: bannerAppear .3s ease-in-out;
 }
@@ -11,46 +11,6 @@
 */
 
 @keyframes bannerAppear {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes onActiveBannerImage {
-  0% {
-    opacity: 0;
-    transform: scale(1.1);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@keyframes onHideBannerImage {
-  0% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(1.05);
-  }
-}
-
-@keyframes onHideBanner {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-@keyframes onActiveBanner {
   0% {
     opacity: 0;
   }

--- a/ui/src/Components/Banners/ProgressBar.scss
+++ b/ui/src/Components/Banners/ProgressBar.scss
@@ -50,7 +50,7 @@
       margin: 0 10px;
       height: 4px;
       width: 175px;
-      background: #ffffff;
+      background: var(--bannerPrimaryTextColor);
       -webkit-appearance: none;
       border-radius: 4px;
       position: relative;

--- a/ui/src/Components/CardList/Card.scss
+++ b/ui/src/Components/CardList/Card.scss
@@ -52,6 +52,7 @@
           position: absolute;
           left: 0;
           width: 0;
+          max-width: 100%;
           height: 4px;
           border-radius: 4px;
           transition: width 200ms ease-in-out;

--- a/ui/src/Components/CardList/Card.scss
+++ b/ui/src/Components/CardList/Card.scss
@@ -16,11 +16,24 @@
 
     .cardImageWrapper {
       position: relative;
+      background: var(--secondaryColor);
       transition: filter 0.2s ease-in-out;
+
+      .imageLoad {
+        animation: onHideImage 0s ease-in-out forwards;
+
+        &.show-true {
+          animation: onActiveImage 300ms ease-in-out forwards;
+        }
+
+        &.show-false {
+          animation: onHideImage 300ms ease-in-out forwards;
+        }
+      }
 
       img {
         object-fit: cover;
-        animation: imageLoaded .3s ease-in;
+        animation: imageLoaded 300ms ease-in;
       }
 
       .progress {
@@ -100,5 +113,23 @@
   }
   100% {
     opacity: 1;
+  }
+}
+
+@keyframes onActiveImage {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes onHideImage {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
   }
 }

--- a/ui/src/Components/CardList/Image.jsx
+++ b/ui/src/Components/CardList/Image.jsx
@@ -1,52 +1,29 @@
-import { useState, useEffect } from "react";
 
 import DimLogo from "../../assets/DimLogo";
+import ImageLoad from "../ImageLoad";
 
-function CardImage(props) {
-  const [loaded, setLoaded] = useState(false);
-  const [error, setErr] = useState(false);
-  const [imageSrc, setImageSrc] = useState();
-
-  useEffect(() => {
-    if(!props.src) return;
-
-    const img = new Image();
-
-    img.onload = () => {
-      setLoaded(true);
-    };
-
-    img.onerror = () => {
-      setLoaded(true);
-      setErr(true);
-    };
-
-    // test whether the src passed is an absolute URL or not
-    // NOTE: see issue #13
-    img.src = new RegExp("/^(?:/|[a-z]+://)/").test(props.src)
-      ? props.src : `/${props.src}`;
-
-    setImageSrc(img.src);
-
-  }, [props.src]);
-
-  return (
-    <div className="cardImageWrapper">
-      {(loaded && !error) && (
-        <img src={imageSrc} alt="cover"/>
+const CardImage = (props) => (
+  <div className="cardImageWrapper">
+    <ImageLoad src={props.src} triggerAnimation="onHideImage">
+      {(imageSrc, loaded, error) => (
+        <>
+          {loaded && !error && (
+            <img src={imageSrc} alt="cover"/>
+          )}
+          {error && (
+            <div className="placeholder">
+              <DimLogo/>
+            </div>
+          )}
+          {props.progress !== undefined && (
+            <div className="progress">
+              <div className="value" style={{width: `${props.progress | 0}%`}}/>
+            </div>
+          )}
+        </>
       )}
-      {error && (
-        <div className="placeholder">
-          <DimLogo/>
-        </div>
-      )}
-      {props.progress !== undefined && (
-        <div className="progress">
-          <div className="value" style={{width: `${props.progress | 0}%`}}/>
-        </div>
-      )}
-    </div>
-  );
-}
+    </ImageLoad>
+  </div>
+);
 
 export default CardImage;

--- a/ui/src/Components/CardList/Index.jsx
+++ b/ui/src/Components/CardList/Index.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 
@@ -13,6 +13,8 @@ function CardList(props) {
   const location = useLocation();
   const dispatch = useDispatch();
 
+  const [throttleEventNewCardID, setThrottleEventNewCardID] = useState(false);
+
   const { ws, cards } = useSelector(store => ({
     cards: store.card.cards,
     ws: store.ws
@@ -25,12 +27,19 @@ function CardList(props) {
   const handleWS = useCallback((e) => {
     const { type } = JSON.parse(e.data);
 
-    console.log("type", type);
-
     if (type === "EventNewCard") {
-      dispatch(fetchCards(path, false));
+      if (throttleEventNewCardID) {
+        clearTimeout(throttleEventNewCardID);
+        setThrottleEventNewCardID();
+      }
+
+      const id = setTimeout(() => {
+        dispatch(fetchCards(path, false));
+      }, 500);
+
+      setThrottleEventNewCardID(id);
     }
-  }, [dispatch, path]);
+  }, [dispatch, path, throttleEventNewCardID]);
 
   useEffect(() => {
     if (!ws.conn) return;

--- a/ui/src/Components/ImageLoad.jsx
+++ b/ui/src/Components/ImageLoad.jsx
@@ -39,7 +39,7 @@ function ImageLoad(props) {
       setLoaded(true);
       setCurrentSrc(props.src);
 
-      if (blob.type === "text/html; charset=utf-8") {
+      if (blob.type === "text/html; charset=utf-8" || req.status !== 200) {
         setShow(true);
         setErr(true);
 

--- a/ui/src/Components/ImageLoad.jsx
+++ b/ui/src/Components/ImageLoad.jsx
@@ -65,6 +65,9 @@ function ImageLoad(props) {
       setImageSrc(imageObjectURL);
       setErr(false);
     } catch (e) {
+      setErr(true);
+      setShow(true);
+
       console.log("[img] unexpected error:", e);
     }
   }, [props.src, signal, tryAgainCount]);

--- a/ui/src/Components/ImageLoad.jsx
+++ b/ui/src/Components/ImageLoad.jsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useCallback } from "react";
+
+function ImageLoad(props) {
+  const [show, setShow] = useState(false);
+  const [signal, setSignal] = useState();
+  const [timeoutID, setTimeoutID] = useState();
+
+  const [loaded, setLoaded] = useState(false);
+  const [error, setErr] = useState(false);
+
+  const [tryAgain, setTryAgain] = useState(false);
+  const [tryAgainCount, setTryAgainCount] = useState(2);
+
+  const [imageSrc, setImageSrc] = useState();
+  const [currentSrc, setCurrentSrc] = useState();
+
+  /*
+    the difference in time between the imageObject being set and
+    rendering the component is enough for smoother onShow animations
+  */
+  useEffect(() => {
+    if (imageSrc) {
+      setShow(true);
+    }
+  }, [imageSrc]);
+
+  const fetchImage = useCallback(async () => {
+    setLoaded(false);
+    setImageSrc();
+    setTryAgain(false);
+    setTimeoutID();
+
+    const src = new RegExp("/^(?:/|[a-z]+://)/").test(props.src) ? props.src : `/${props.src}`;
+
+    try {
+      const req = await fetch(src, {signal});
+      const blob = await req.blob();
+
+      setLoaded(true);
+      setCurrentSrc(props.src);
+
+      if (blob.type === "text/html; charset=utf-8") {
+        setShow(true);
+        setErr(true);
+
+        /*
+          prevents trying to re-fetch every time
+          the user navigates or reloads a page.
+        */
+        if (tryAgainCount > 0) {
+          const triedAlready = sessionStorage.getItem(props.src);
+
+          if (!triedAlready) {
+            setTryAgain(true);
+          }
+        } else {
+          sessionStorage.setItem(props.src, "skip");
+        }
+
+        return;
+      }
+
+      const imageObjectURL = URL.createObjectURL(blob);
+
+      setImageSrc(imageObjectURL);
+      setErr(false);
+    } catch (e) {
+      console.log("[img] unexpected error:", e);
+    }
+  }, [props.src, signal, tryAgainCount]);
+
+  useEffect(() => {
+    if (tryAgain && !timeoutID) {
+      setTryAgainCount(state => state - 1);
+
+      const id = setTimeout(() => {
+        fetchImage();
+      }, 3000);
+
+      setTimeoutID(id);
+    }
+
+    return () => {
+      if (timeoutID) {
+        clearTimeout(timeoutID);
+      }
+    };
+  }, [fetchImage, timeoutID, tryAgain]);
+
+  const handleAnimationEnd = useCallback((e) => {
+    if (e.animationName !== props.triggerAnimation) return;
+
+    fetchImage();
+    setTryAgainCount(2);
+  }, [fetchImage, props.triggerAnimation]);
+
+  useEffect(() => {
+    // setShow(true);
+    if (props.src === currentSrc) return;
+    setShow(false);
+  }, [currentSrc, props.src]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const acSignal = controller.signal;
+
+    setSignal(acSignal);
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  if (!signal) return null;
+
+  return (
+    <div
+      className={`imageLoad show-${show}`}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      {props.children(imageSrc, loaded, error)}
+    </div>
+  );
+}
+
+export default ImageLoad;

--- a/ui/src/Components/ImageLoad.jsx
+++ b/ui/src/Components/ImageLoad.jsx
@@ -39,7 +39,7 @@ function ImageLoad(props) {
       setLoaded(true);
       setCurrentSrc(props.src);
 
-      if (blob.type === "text/html; charset=utf-8" || req.status !== 200) {
+      if (blob.type.includes("text/html") || req.status !== 200) {
         setShow(true);
         setErr(true);
 

--- a/ui/src/Components/Sidebar/Index.jsx
+++ b/ui/src/Components/Sidebar/Index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch} from "react-redux";
 
 import { fetchUser } from "../../actions/user.js";
 import { fetchUserSettings } from "../../actions/settings.js";
@@ -17,10 +17,6 @@ function Sidebar() {
   const dispatch = useDispatch();
   const divContainer = useRef(null);
 
-  const libraries = useSelector(store => (
-    store.library.fetch_libraries
-  ));
-
   useEffect(() => {
     dispatch(fetchLibraries());
     dispatch(fetchUser());
@@ -35,9 +31,7 @@ function Sidebar() {
           <div className="separator"/>
           <Search/>
         </section>
-        {libraries.items.length > 0 && (
-          <Libraries/>
-        )}
+        <Libraries/>
         <General/>
       </div>
       <Toggle sidebar={divContainer}/>

--- a/ui/src/Components/Sidebar/Libraries.jsx
+++ b/ui/src/Components/Sidebar/Libraries.jsx
@@ -52,6 +52,8 @@ function Libraries() {
     ));
   }
 
+  if (libraries.items.length === 0) return null;
+
   return (
     <section className="libraries">
       <header>

--- a/ui/src/Pages/Media/Banner.scss
+++ b/ui/src/Pages/Media/Banner.scss
@@ -60,7 +60,7 @@
     border-radius: 10px;
     overflow: hidden;
     height: 100%;
-    width: auto;
+    width: 100%;
     position: relative;
     display: inline-block;
 
@@ -122,14 +122,14 @@
 */
 
 @media only screen and (max-width: 2560px) and (max-height: 1440px) {
-  .backdrop img {
+  .backdrop .bannerImageWrapper .imageLoad img {
     object-position: 30% 30%;
   }
 }
 
 @media only screen and (max-width: 720px) and (max-height: 1440px) {
-  .backdrop img {
-    object-position: 50%;
+  .backdrop .bannerImageWrapper .imageLoad {
+    object-position: 50% !important;
   }
 }
 

--- a/ui/src/Pages/Media/Banner.scss
+++ b/ui/src/Pages/Media/Banner.scss
@@ -27,13 +27,27 @@
     width: auto;
     height: 100%;
     overflow: hidden;
+    background: #2a2a2a;
 
-    img {
-      animation: appear .3s ease-in-out;
+    .imageLoad {
       height: inherit;
       width: inherit;
-      object-fit: cover;
-      object-position: bottom;
+      animation: onHideImage 0s ease-in-out forwards;
+
+      &.show-true {
+        animation: onActiveImage 300ms ease-in-out forwards;
+      }
+
+      &.show-false {
+        animation: onHideImage 300ms ease-in-out forwards;
+      }
+
+      img {
+        height: inherit;
+        width: inherit;
+        object-fit: cover;
+        object-position: bottom;
+      }
     }
 
     .placeholder {
@@ -46,12 +60,32 @@
     border-radius: 10px;
     overflow: hidden;
     height: 100%;
-    width: 100%;
+    width: auto;
     position: relative;
     display: inline-block;
 
+    .imageLoad {
+      height: inherit;
+      width: inherit;
+      animation: onHideImage 0s ease-in-out forwards;
+
+      &.show-true {
+        animation: onActiveImage 300ms ease-in-out forwards;
+      }
+
+      &.show-false {
+        animation: onHideImage 300ms ease-in-out forwards;
+      }
+
+      img {
+        height: inherit;
+        width: inherit;
+        object-fit: cover;
+        object-position: bottom;
+      }
+    }
+
     img {
-      animation: appear .3s ease-in-out;
       transition: object-position 0.3s ease-in-out;
       object-fit: cover;
       border-radius: 10px;
@@ -62,7 +96,29 @@
 }
 
 /*
-    * == MEDIA QUERIES ==
+  * == KEYFRAMES ==
+*/
+
+@keyframes onActiveImage {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes onHideImage {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/*
+  * == MEDIA QUERIES ==
 */
 
 @media only screen and (max-width: 2560px) and (max-height: 1440px) {

--- a/ui/src/Pages/Media/BannerImage.jsx
+++ b/ui/src/Pages/Media/BannerImage.jsx
@@ -1,40 +1,21 @@
-import { useState, useEffect } from "react";
+import DimLogo from "../../assets/DimLogo";
+import ImageLoad from "../../Components/ImageLoad";
 
-function BannerImage(props) {
-  const [loaded, setLoaded] = useState(false);
-  const [error, setErr] = useState(false);
-  const [imgSrc, setImgSrc] = useState();
-
-  useEffect(() => {
-    if (props.src === undefined) return;
-
-    const img = new Image();
-
-    img.onload = () => {
-      setImgSrc(img.src);
-      setLoaded(true);
-      setErr(false);
-    };
-
-    img.onerror = () => {
-      setLoaded(true);
-      setErr(true);
-    };
-
-    img.src = new RegExp("/^(?:/|[a-z]+://)/").test(props.src)
-      ? props.src : `/${props.src}`;
-  }, [props.src]);
-
-  return (
-    <div className="bannerImageWrapper">
-      {(loaded && !error) && (
-        <img src={imgSrc} alt="cover"/>
-      )}
-      {error && (
-        <div className="placeholder"/>
-      )}
-    </div>
-  );
-}
+const BannerImage = (props) => (
+  <div className="bannerImageWrapper">
+    <ImageLoad src={props.src} triggerAnimation="onHideImage">
+      {(imageSrc, loaded, error) => {
+        if (loaded && !error) return (
+          <img src={imageSrc} alt="banner"/>
+        );
+        if (error) return (
+          <div className="placeholder">
+            <DimLogo/>
+          </div>
+        );
+      }}
+    </ImageLoad>
+  </div>
+);
 
 export default BannerImage;

--- a/ui/src/Pages/Media/CardImage.jsx
+++ b/ui/src/Pages/Media/CardImage.jsx
@@ -1,45 +1,28 @@
-import { useState, useEffect } from "react";
+import ImageLoad from "../../Components/ImageLoad";
+import DimLogo from "../../assets/DimLogo";
 
-function CardImage(props) {
-  const [loaded, setLoaded] = useState(false);
-  const [error, setErr] = useState(false);
-  const [imgSrc, setImgSrc] = useState();
-
-  useEffect(() => {
-    if (props.src === undefined) return;
-
-    const img = new Image();
-
-    img.onload = () => {
-      setImgSrc(img.src);
-      setLoaded(true);
-      setErr(false);
-    };
-
-    img.onerror = () => {
-      setLoaded(true);
-      setErr(true);
-    };
-
-    img.src = new RegExp("/^(?:/|[a-z]+://)/").test(props.src)
-      ? props.src : `/${props.src}`;
-  }, [props.src]);
-
-  return (
-    <div className="cardImageWrapper">
-      {(loaded && !error) && (
-        <img src={imgSrc} alt="cover"/>
+const CardImage = (props) => (
+  <div className="cardImageWrapper">
+    <ImageLoad src={props.src} triggerAnimation="onHideImage">
+      {(imageSrc, loaded, error) => (
+        <>
+          {loaded && !error && (
+            <img src={imageSrc} alt="cover"/>
+          )}
+          {error && (
+            <div className="placeholder">
+              <DimLogo/>
+            </div>
+          )}
+          {props.progress !== undefined && (
+            <div className="progress">
+              <div className="value" style={{width: `${props.progress | 0}%`}}/>
+            </div>
+          )}
+        </>
       )}
-      {(loaded && error) && (
-        <div className="placeholder"/>
-      )}
-      {props.progress !== undefined && (
-        <div className="progress">
-          <div className="value" style={{width: `${props.progress | 0}%`}}/>
-        </div>
-      )}
-    </div>
-  );
-}
+    </ImageLoad>
+  </div>
+);
 
 export default CardImage;

--- a/ui/src/Pages/Media/Index.scss
+++ b/ui/src/Pages/Media/Index.scss
@@ -51,10 +51,36 @@
           transition: 0.2s ease-in-out;
           transition-property: filter, opacity;
 
-          img {
+          .placeholder {
             height: 100%;
             width: 100%;
-            object-fit: cover;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            svg {
+              width: 48px;
+            }
+          }
+
+          .imageLoad {
+            height: 100%;
+            width: 100%;
+            animation: onHideImage 0s ease-in-out forwards;
+
+            &.show-true {
+              animation: onActiveImage 300ms ease-in-out forwards;
+            }
+
+            &.show-false {
+              animation: onHideImage 300ms ease-in-out forwards;
+            }
+
+            img {
+              height: 100%;
+              width: 100%;
+              object-fit: cover;
+            }
           }
         }
       }
@@ -85,10 +111,36 @@
           overflow: hidden;
           transition: filter 0.2s ease-in-out;
 
-          img {
+          .placeholder {
             height: 100%;
             width: 100%;
-            object-fit: cover;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            svg {
+              width: 48px;
+            }
+          }
+
+          .imageLoad {
+            height: 100%;
+            width: 100%;
+            animation: onHideImage 0s ease-in-out forwards;
+
+            &.show-true {
+              animation: onActiveImage 300ms ease-in-out forwards;
+            }
+
+            &.show-false {
+              animation: onHideImage 300ms ease-in-out forwards;
+            }
+
+            img {
+              height: 100%;
+              width: 100%;
+              object-fit: cover;
+            }
           }
 
           .progress {
@@ -151,6 +203,25 @@
     opacity: 1;
   }
 }
+
+@keyframes onActiveImage {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes onHideImage {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
 
 /*
     * == MEDIA QUERIES ==

--- a/ui/src/Pages/Media/Index.scss
+++ b/ui/src/Pages/Media/Index.scss
@@ -159,6 +159,7 @@
               position: absolute;
               left: 0;
               width: 0;
+              max-width: 100%;
               height: 4px;
               border-radius: 4px;
               transition: width 200ms ease-in-out;

--- a/ui/src/Themes/Blind.js
+++ b/ui/src/Themes/Blind.js
@@ -14,10 +14,13 @@ const Blind = {
   quinaryColor: "#bbb",
   senaryColor: "#aaa",
   septenaryColor: "#999",
-  bannerPrimaryColor: "#3a3a3a",
+  bannerPrimaryColor: "#2a2a2a",
+  bannerSecondaryColor: "#3a3a3a",
   bannerPrimaryTextColor: "#fff",
   bannerSecondaryTextColor: "#ddd",
-  bannerTertiaryTextColor: "#ccc"
+  bannerTertiaryTextColor: "#ccc",
+  bannerBottomBorderColor: "#3a3a3a",
+  bannerOverlayShadow: "#1a1a1add"
 };
 
 export default Blind;

--- a/ui/src/Themes/Default.js
+++ b/ui/src/Themes/Default.js
@@ -14,10 +14,13 @@ const Default = {
   quinaryColor: "#5a5a5a",
   senaryColor: "#6a6a6a",
   septenaryColor: "#7a7a7a",
-  bannerPrimaryColor: "#3a3a3a",
+  bannerPrimaryColor: "#2a2a2a",
+  bannerSecondaryColor: "#3a3a3a",
   bannerPrimaryTextColor: "#fff",
   bannerSecondaryTextColor: "#ddd",
-  bannerTertiaryTextColor: "#ccc"
+  bannerTertiaryTextColor: "#ccc",
+  bannerBottomBorderColor: "#3a3a3a",
+  bannerOverlayShadow: "#1a1a1add"
 };
 
 export default Default;

--- a/ui/src/Themes/LightsOff.js
+++ b/ui/src/Themes/LightsOff.js
@@ -15,9 +15,12 @@ const LightsOff = {
   senaryColor: "#404040",
   septenaryColor: "#505050",
   bannerPrimaryColor: "#101010",
+  bannerSecondaryColor: "#202020",
   bannerPrimaryTextColor: "#eee",
   bannerSecondaryTextColor: "#ccc",
-  bannerTertiaryTextColor: "#bbb"
+  bannerTertiaryTextColor: "#bbb",
+  bannerBottomBorderColor: "#303030",
+  bannerOverlayShadow: "#151515cc"
 };
 
 export default LightsOff;


### PR DESCRIPTION
All images across Dim _should_ now:
- [x] Swap smoothly between sources _(if an animation is given ofc, by default simple opacity change)_
- [x] Retry to fetch again every 5 seconds 3 times if failed to load - only per window session _(to not spam)_
- [x] Cancel fetch if user navigates away.

Other changes
- Fixes libraries section in sidebar not showing when adding new library for the first time
- Theme and favicon should now work even if server is offline because they were housed under the WS component
- Tweaks to banner colors
