### PR TITLE
Fix some bugs regarding global settings.

### DIFF
--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -56,6 +56,7 @@ warp = { version = "0.3.1", features = ["tls", "tokio-rustls"] }
 http = "^0.2.3"
 structopt = "0.3.21"
 sqlx = "0.5.5"
+toml = "0.5.8"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/src/main.rs
+++ b/dim/src/main.rs
@@ -18,7 +18,7 @@ use structopt::StructOpt;
 #[structopt(version = env!("CARGO_PKG_VERSION"), author = env!("CARGO_PKG_AUTHORS"))]
 #[structopt(rename_all = "kebab")]
 struct Args {
-    #[structopt(short, long, parse(from_os_str), default_value = "config.json")]
+    #[structopt(short, long, parse(from_os_str), default_value = "config.toml")]
     config: PathBuf,
     /// Enables debug mode, which enables debug logs.
     #[structopt(short, long)]


### PR DESCRIPTION
- [ ] Saving settings twice causes old changes to be overwritten to defaults.
- [ ] Undoing a change saved to metadata_path or cache_path is not possible unless the page is refreshed.