### PR TITLE
Update node-sass

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "dashjs": "^4.1.0",
     "http-proxy-middleware": "^2.0.1",
     "libass-wasm": "^4.0.0",
-    "node-sass": "^5.0.0",
+    "node-sass": "^6.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.1",
     "react-modal": "^3.12.1",


### PR DESCRIPTION
This brings compatibility with Node 16, the current LTS version of Node.

With node-sass 5, the latest supported Node version is Node 15, and `yarn install` fails when building native dependencies.