### PR TITLE
Hide ID of media

### DIFF
--- a/ui/src/Pages/Media/MetaContent.jsx
+++ b/ui/src/Pages/Media/MetaContent.jsx
@@ -88,10 +88,6 @@ function MetaContent() {
         <p className="description">{description}</p>
         <div className="meta-info">
           <div className="info">
-            <h4>ID</h4>
-            <p>{id}</p>
-          </div>
-          <div className="info">
             <h4>Type</h4>
             <p>{media_type}</p>
           </div>


### PR DESCRIPTION
@sadstan
> 2) Avoid displaying the movie id when you open the movie details page

Reasoning: _I think if some1 needs it, they can look at the URL. Since, I am the admin, I understand it. But it seems unnecessary that my users see that info, which they most likely wont understand.
Also, as an admin, if I ever need the ID, I can simply look at the url of the page. Imho, it can be done away with completely, and that UI space better utilized with something else._

Which, I agree with. Also, I tried maybe filling the empty space with the play button but did not look as nice as I hoped, either way, data such as ID will move into it's own detailed dropdown section in the future.