### PR TITLE
Lazy load images in Card component

### DIFF
--- a/ui/src/Components/Card/Image.jsx
+++ b/ui/src/Components/Card/Image.jsx
@@ -8,7 +8,7 @@ const CardImage = (props) => (
       {({imageSrc, loaded, error, setErr}) => (
         <>
           {loaded && !error && (
-            <img src={imageSrc} alt="cover" onError={() => setErr(true)}/>
+            <img src={imageSrc} alt="cover" loading="lazy" onError={() => setErr(true)}/>
           )}
           {error && (
             <div className="placeholder">


### PR DESCRIPTION
Noticed that images weren't lazy loaded. This is a simple fix without polyfills, but thus also without dependencies.

Works in Firefox and Chromium based browsers https://caniuse.com/loading-lazy-attr 
https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes