### PR TITLE
revise inital creation of dim_dev.db

### DIFF
--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -3,6 +3,7 @@ name = "database"
 version = "0.1.0"
 authors = ["Valerian G. <valerian.garleanu@pm.me>"]
 edition = "2018"
+build = "src/build.rs"
 
 [features]
 default = ["sqlite"]
@@ -26,3 +27,9 @@ once_cell = "1.8.0"
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
+
+[build-dependencies]
+fs_extra = "1.1.0"
+sqlx = { version = "=0.5.5" }
+tokio = "1.12.0"
+dotenv = "0.15.0"

--- a/database/src/build.rs
+++ b/database/src/build.rs
@@ -1,0 +1,54 @@
+use std::env;
+use std::path::Path;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // The env vars are not necessarily provided by a .env file, so ignore err.
+    dotenv::dotenv().ok();
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").map_err(|e| {
+        println!("cargo:error=CARGO_MANIFEST_DIR is not set");
+        e
+    })?);
+    let mut db_file = env::var("DATABASE_URL").map_err(|e| {
+        println!("cargo:error=DATABASE_URL is not set");
+        e
+    })?;
+    if db_file.starts_with("sqlite://") {
+        db_file = db_file.split_off(9);
+    }
+
+    let mut db_path = manifest_dir.clone();
+    db_path.pop();
+    db_path.push(&db_file);
+
+    if !Path::new(&db_path).exists() {
+        println!(
+            "cargo:warning=Generating {:?} from latest migrations.",
+            db_file
+        );
+
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect_with(
+                sqlx::sqlite::SqliteConnectOptions::from_str(db_path.to_string_lossy().as_ref())?
+                    .create_if_missing(true),
+            )
+            .await?;
+
+        sqlx::migrate!().run(&pool).await.map_err(|e| {
+            println!("cargo:error=Migration failed: {:?}", e);
+            e
+        })?;
+        println!(
+            "cargo:warning=Built database {}.",
+            db_path.to_string_lossy().as_ref()
+        );
+    }
+
+    println!("cargo:rerun-if-changed=ui/build");
+    println!("cargo:rerun-if-changed=build.rs");
+    Ok(())
+}

--- a/dim/src/build.rs
+++ b/dim/src/build.rs
@@ -1,7 +1,4 @@
-use std::env;
 use std::path::Path;
-use std::path::PathBuf;
-use std::process::Command;
 
 fn main() {
     if Path::new("../ui/build").exists() {
@@ -9,38 +6,6 @@ fn main() {
     } else {
         println!("cargo:warning=`ui/build` does not exist.");
         println!("cargo:warning=If you wish to embed the webui, run `yarn build` in `ui`.");
-    }
-
-    let mut manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap_or("./".into()));
-    let mut migrations_path = manifest_dir.clone();
-    migrations_path.pop();
-    manifest_dir.pop();
-    manifest_dir.push("dim_dev.db");
-    migrations_path.push("database/migrations/*.sql");
-
-    if !Path::new(&manifest_dir).exists() {
-        println!(
-            "cargo:warning=Generating {:?} from latest migrations.",
-            manifest_dir
-        );
-        println!(
-            "cargo:warning=Using migrations located at {:?}",
-            migrations_path
-        );
-        let process = Command::new("sqlite3")
-            .args(&[
-                "-init",
-                migrations_path.to_string_lossy().as_ref(),
-                manifest_dir.to_string_lossy().as_ref(),
-            ])
-            .output()
-            .expect("Failed to generate dim_dev.db from latest migrations.");
-
-        println!("cargo:warning={}", String::from_utf8_lossy(&process.stdout));
-        println!(
-            "cargo:warning=Sqlite3 exited with {:?}.",
-            process.status.code()
-        );
     }
 
     println!("cargo:rerun-if-changed=ui/build");


### PR DESCRIPTION
This is a second attempt at revising the build.rs scripts to create an initial initial dim_dev.db.

Like last time, there are a couple of conventions that are followed here:

the sqlx migrate!() macro assumes it will run in the crate where the migrations directory resides.  
For that reason, the migrations are moved from dim/src/build.rs to database/src/build.rs.

database/src/build.rs reads the database file path from the top level .env file, in order, to match the location used by the sqlx query!() macros.

I also eliminated the use of anyhow, instead using map_err() that sends error messages to cargo.

Just let me know if there are additional conventions that are preferred.  And feel free to cherry pick anything or nothing, or change this however you see fit!  I'm completely new to dim, so directions are welcome.

