### PR TITLE
fix bug with the hovercard play button showing a empty file picker.

### DIFF
--- a/dim/src/routes/media.rs
+++ b/dim/src/routes/media.rs
@@ -217,6 +217,7 @@ pub async fn get_media_by_id(
                             "progress": delta,
                             "season": next_episode.get_season_number(&conn).await.unwrap_or(0),
                             "episode": next_episode.episode,
+                            "play_btn_id": next_episode.id,
                         }))
                     } else {
                         None
@@ -226,6 +227,7 @@ pub async fn get_media_by_id(
                         "progress": delta,
                         "season": ep.get_season_number(&conn).await.unwrap_or(0),
                         "episode": ep.episode,
+                        "play_btn_id": ep.id,
                     }))
                 }
             } else {
@@ -234,6 +236,7 @@ pub async fn get_media_by_id(
                     "progress": 0,
                     "season": ep.get_season_number(&conn).await.unwrap_or(0),
                     "episode": ep.episode,
+                    "play_btn_id": ep.id,
                 }))
             }
         }

--- a/ui/src/Components/Card/HoverCard.jsx
+++ b/ui/src/Components/Card/HoverCard.jsx
@@ -64,7 +64,7 @@ function HoverCard(props) {
 
   // FETCH_MEDIA_INFO_OK
   if (fetched && !error) {
-    const { duration, genres, rating, description, year, progress, season, episode } = data;
+    const { duration, genres, rating, description, year, progress, season, episode, play_btn_id } = data;
 
     const length = {
       hh: ("0" + Math.floor(duration / 3600)).slice(-2),
@@ -126,7 +126,7 @@ function HoverCard(props) {
               <p>{length.hh}:{length.mm}:{length.ss}</p>
               <p>HH MM SS</p>
             </div>
-            <SelectMediaFile title={name} mediaID={id}>
+            <SelectMediaFile title={name} mediaID={play_btn_id || id}>
               <SelectMediaFilePlayButton progress={progress} seasonep={{season, episode}}/>
             </SelectMediaFile>
           </section>


### PR DESCRIPTION
Turns out the `/media/<id>` api route wasnt returning the id of the episode the play button should select, and the UI was incorrectly assuming it should use the media id instead.

Fixes: #283 