### PR TITLE
Added library libtheora0 to the list of required libraries. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dim is a self-hosted media manager. With minimal setup, Dim will organize and be
   * libtheora
   * libvorbis
   * libvorbisenc
+  * libtheora0
 
   You can then obtain binaries from the release tab in github:
   1. Unpack with `unzip ./release-linux.zip && tar -xvzf ./release.tar.gz`


### PR DESCRIPTION
This library is required for the bundled FFMPEG, but it is not always included by default by the OS. An example is `images:ubuntu/focal` on LXD, it does not include libtheora0