### PR TITLE
Make theme-color meta tag reactive

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "node-sass": "^6.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.1",
+    "react-helmet": "^6.1.0",
     "react-modal": "^3.12.1",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.0",

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -3,7 +3,6 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, user-scalable=no"/>
-    <meta name="theme-color" content="#1a1a1a"/>
 		<link rel="icon" sizes="128x128" id="favicon" href="%PUBLIC_URL%/static/logoWhite128.png" type="image/png"/>
 		<link rel="icon" sizes="512x512" id="textFavicon" href="%PUBLIC_URL%/static/logoWhite512.png" type="image/png"/>
     <link rel="manifest" href="%PUBLIC_URL%/static/manifest.json"/>

--- a/ui/src/Controllers/Theme.jsx
+++ b/ui/src/Controllers/Theme.jsx
@@ -1,5 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { Helmet } from "react-helmet";
 
 import DefaultTheme from "../Themes/Default";
 import BlindTheme from "../Themes/Blind";
@@ -7,6 +8,7 @@ import LightsOff from "../Themes/LightsOff";
 
 function ThemeController() {
   const userSettings = useSelector(store => store.settings.userSettings);
+  const [themeColor, setThemeColor] = useState("#1a1a1a");
 
   useEffect(() => {
     switch(userSettings.data.theme) {
@@ -14,23 +16,30 @@ function ThemeController() {
         for (const prop in DefaultTheme) {
           document.documentElement.style.setProperty(`--${prop}`, `${DefaultTheme[prop]}`);
         }
+        setThemeColor(userSettings.data.theme.primaryColor);
         break;
       case "Light":
         for (const prop in BlindTheme) {
           document.documentElement.style.setProperty(`--${prop}`, `${BlindTheme[prop]}`);
         }
+        setThemeColor(userSettings.data.theme.primaryColor);
         break;
       case "Black":
         for (const prop in LightsOff) {
           document.documentElement.style.setProperty(`--${prop}`, `${LightsOff[prop]}`);
         }
+        setThemeColor(userSettings.data.theme.primaryColor);
         break;
       default:
         break;
     }
-  }, [userSettings.data.theme]);
+  }, [setThemeColor, userSettings.data.theme]);
 
-  return null;
+  return (
+    <Helmet>
+      <meta name="theme-color" content={themeColor} />
+    </Helmet>
+  );
 }
 
 export default ThemeController;


### PR DESCRIPTION
This adds react-helmet, in order to make the `theme-color` meta tag react to the currently enabled theme.

It uses the primaryColor, as that seems to be what was used previously.

![Screenshot 2021-11-20 at 16 59 53](https://user-images.githubusercontent.com/19396809/142732963-17c2b728-b378-467f-bfc2-a1f3866001ce.png)

![Screenshot 2021-11-20 at 17 00 09](https://user-images.githubusercontent.com/19396809/142732965-131c365e-20e1-4fda-8356-83b77f7fb2af.png)

![Screenshot 2021-11-20 at 16 59 47](https://user-images.githubusercontent.com/19396809/142732968-00b3b8e3-799a-444c-a417-df228990dfb6.png)

