### PR TITLE
Moving tmdb to its own workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["dim", "database", "auth", "events"]
+members = ["dim", "database", "auth", "events", "tmdb_api"]
 
 [profile.dev]
 codegen-units = 16

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "^1.0.64"
 database = { path = "../database", default-features = false, optional = true }
 events = { path = "../events" }
 auth = { path = "../auth" }
+tmdb_api = { path = "../tmdb_api" }
 
 nightfall = { git = "https://github.com/Dusk-Labs/nightfall", tag = "0.3.12-rc4", features = ["ssa_transmux"] }
 

--- a/dim/src/routes/media.rs
+++ b/dim/src/routes/media.rs
@@ -414,7 +414,7 @@ pub async fn tmdb_search(
     media_type: String,
     _user: Auth,
 ) -> Result<impl warp::Reply, errors::DimError> {
-    use crate::scanners::tmdb::Tmdb;
+    use tmdb_api::Tmdb;
 
     let media_type = match media_type.as_ref() {
         "movie" => MediaType::Movie,
@@ -430,7 +430,7 @@ pub async fn tmdb_search(
             .await
             .map_err(|_| errors::DimError::NotFoundError)?
             .into_iter()
-            .map(Into::<crate::scanners::ApiMedia>::into)
+            .map(Into::<tmdb_api::ApiMedia>::into)
             .collect::<Vec<_>>(),
     ))
 }

--- a/dim/src/routes/mediafile.rs
+++ b/dim/src/routes/mediafile.rs
@@ -102,7 +102,7 @@ pub async fn rematch_mediafile(
     tmdb_id: i32,
     media_type: String,
 ) -> Result<impl warp::Reply, errors::DimError> {
-    use crate::scanners::tmdb::Tmdb;
+    use tmdb_api::Tmdb;
     use database::library::MediaType;
 
     let mut tx = conn.read().begin().await?;

--- a/dim/src/scanners/base.rs
+++ b/dim/src/scanners/base.rs
@@ -10,6 +10,8 @@ use tracing::instrument;
 use tracing::warn;
 use tracing::Instrument;
 
+use tmdb_api::Tmdb;
+use tmdb_api::ApiMedia;
 use database::library::MediaType;
 use database::mediafile::InsertableMediaFile;
 use database::mediafile::MediaFile;
@@ -18,12 +20,9 @@ use database::DbConnection;
 
 use crate::core::EventTx;
 use crate::scanners::movie::MovieMatcher;
-use crate::scanners::tmdb::Tmdb;
 use crate::scanners::tv_show::TvShowMatcher;
 use crate::streaming::ffprobe::FFProbeCtx;
 use crate::streaming::FFPROBE_BIN;
-
-use super::ApiMedia;
 
 use torrent_name_parser::Metadata;
 
@@ -383,7 +382,7 @@ impl MetadataMatcher {
             .map_err(|e| ScannerError::DatabaseError(format!("{:?}", e)))?;
         drop(lock);
 
-        let mut seasons: Vec<super::ApiSeason> = self
+        let mut seasons: Vec<tmdb_api::ApiSeason> = self
             .tv_tmdb
             .get_seasons_for(result.id)
             .await

--- a/dim/src/scanners/mod.rs
+++ b/dim/src/scanners/mod.rs
@@ -1,7 +1,6 @@
 pub mod base;
 pub mod movie;
 pub mod scanner_daemon;
-pub mod tmdb;
 pub mod tv_show;
 
 use database::library::Library;
@@ -20,9 +19,13 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
 
+/*
 use serde::Deserialize;
 use serde::Serialize;
 
+ * ApiMedia,ApiSeason moved to tmdb_api
+ *
+ *
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ApiMedia {
     pub id: u64,
@@ -57,6 +60,8 @@ pub struct ApiEpisode {
     pub still: Option<String>,
     pub still_file: Option<String>,
 }
+
+*/
 
 pub(super) static METADATA_EXTRACTOR: OnceCell<base::MetadataExtractor> = OnceCell::new();
 pub(super) static METADATA_MATCHER: OnceCell<base::MetadataMatcher> = OnceCell::new();

--- a/dim/src/scanners/movie.rs
+++ b/dim/src/scanners/movie.rs
@@ -31,7 +31,7 @@ pub struct MovieMatcher<'a> {
 
 impl<'a> MovieMatcher<'a> {
     #[instrument(skip(self, result), fields(result.id = %result.id, result.name = %result.title))]
-    pub async fn match_to_result(&self, result: super::ApiMedia, orphan: &'a MediaFile) {
+    pub async fn match_to_result(&self, result: tmdb_api::ApiMedia, orphan: &'a MediaFile) {
         let library_id = orphan.library_id;
 
         let mut lock = self.conn.writer().lock_owned().await;
@@ -61,7 +61,7 @@ impl<'a> MovieMatcher<'a> {
 
     pub async fn inner_match(
         &self,
-        result: super::ApiMedia,
+        result: tmdb_api::ApiMedia,
         orphan: &'a MediaFile,
         tx: &mut database::Transaction<'_>,
         reuse_media_id: Option<i64>,
@@ -167,7 +167,7 @@ impl<'a> MovieMatcher<'a> {
         &self,
         orphan: &MediaFile,
         media: InsertableMedia,
-        result: super::ApiMedia,
+        result: tmdb_api::ApiMedia,
         tx: &mut database::Transaction<'_>,
         reuse_media_id: Option<i64>,
     ) -> Result<i64, super::base::ScannerError> {

--- a/dim/src/scanners/tv_show.rs
+++ b/dim/src/scanners/tv_show.rs
@@ -37,7 +37,7 @@ pub struct TvShowMatcher<'a> {
 
 impl<'a> TvShowMatcher<'a> {
     #[instrument(skip(self, result, orphan), fields(result.id = %result.id, result.name = %result.title, orphan.id = %orphan.id))]
-    pub async fn match_to_result(&self, result: super::ApiMedia, orphan: &'a MediaFile) {
+    pub async fn match_to_result(&self, result: tmdb_api::ApiMedia, orphan: &'a MediaFile) {
         let library_id = orphan.library_id;
         let mut lock = self.conn.writer().lock_owned().await;
         let mut tx = match database::write_tx(&mut lock)
@@ -68,7 +68,7 @@ impl<'a> TvShowMatcher<'a> {
 
     pub async fn inner_match(
         &self,
-        result: super::ApiMedia,
+        result: tmdb_api::ApiMedia,
         orphan: &'a MediaFile,
         tx: &mut database::Transaction<'_>,
         reuse_media_id: Option<i64>,
@@ -174,7 +174,7 @@ impl<'a> TvShowMatcher<'a> {
         &self,
         orphan: &MediaFile,
         media: InsertableMedia,
-        result: super::ApiMedia,
+        result: tmdb_api::ApiMedia,
         tx: &mut database::Transaction<'_>,
         reuse_media_id: Option<i64>,
     ) -> Result<i64, super::base::ScannerError> {

--- a/tmdb_api/Cargo.toml
+++ b/tmdb_api/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tmdb_api"
+version = "0.3.0-rc6"
+authors = ["Valerian G. <valerian@dusklabs.io>"]
+edition = "2018"
+
+[dependencies]
+database = { path = "../database/" }
+
+serde = { version = "^1.0.125", default-features = false, features = [
+    "derive",
+    "std",
+] }
+serde_derive = "^1.0.125"
+serde_json = "^1.0.64"
+err-derive = "^0.3.0"
+tokio = { version = "1", features = ["rt", "signal"] }
+futures = "0.3.14"
+reqwest = { version = "0.11.0", features = [
+    "json",
+    "default-tls",
+], default-features = false }
+async-trait = "0.1.50"
+async-recursion = "0.3.2"
+lazy_static = "1.4.0"

--- a/ui/src/Pages/Auth/RegisterBtn.jsx
+++ b/ui/src/Pages/Auth/RegisterBtn.jsx
@@ -33,8 +33,8 @@ function RegisterBtn(props) {
       return;
     }
 
-    if (pass.length < 8) {
-      setPassErr("Minimum 8 characters.");
+    if (pass.length < 3) {
+      setPassErr("Minimum 3 characters.");
       return;
     }
 


### PR DESCRIPTION
Working on https://github.com/Dusk-Labs/dim/issues/241

Moved `tmdb.rs` to its own workspace. Need to also move `ApiMedia`, `ApiSeason`, `ApiEpisode` since the tmdb module used those structs. 

Also uncommented and fixed tests for tmdb module. 