### PR TITLE
Pick the first video track if none are marked as default.

### DIFF
--- a/ui/src/Pages/VideoPlayer/Index.jsx
+++ b/ui/src/Pages/VideoPlayer/Index.jsx
@@ -205,7 +205,11 @@ function VideoPlayer() {
     const getInitialTrack = (trackArr) => {
       const trackList =
         trackArr[0].type === "video" ? videoTracks.list : audioTracks.list;
-      const defaultTrack = trackList.filter((track) => track.is_default)[0];
+      const defaultTracks = trackList.filter((track) => track.is_default);
+      const defaultTrack =
+        defaultTracks && defaultTracks.length > 0
+          ? defaultTracks[0]
+          : trackList[0];
       const initialTracks = trackArr.filter(
         (x) => x.id === defaultTrack.set_id
       );


### PR DESCRIPTION
The video player page wasn't loading for me because the code assumed that at least one of the tracks would be marked with `is_default`, which apparently isn't always true. This change selects the first track if none are marked with `is_default`.