### PR TITLE
Clean up IntersectionObserver when CardImage is unmounted.

### DIFF
--- a/ui/src/Components/Card/Image.jsx
+++ b/ui/src/Components/Card/Image.jsx
@@ -26,6 +26,7 @@ const CardImage = (props) => {
 
     const observer = new IntersectionObserver(handleIntersection, options);
     observer.observe(imageWrapperDiv.current);
+    return () => observer.disconnect();
   }, [handleIntersection]);
 
   return (


### PR DESCRIPTION
Fixes a memory leak in the CardImage component:

<img width="952" alt="CardImage_useEffect_memory_leak" src="https://user-images.githubusercontent.com/122457/148662364-523a2de1-d991-44f0-aed4-d3e448d4d0a5.png">

