### PR TITLE
Return HTTP 400 for NoTokenError and UsernameTaken.

### DIFF
--- a/dim/src/errors.rs
+++ b/dim/src/errors.rs
@@ -116,7 +116,7 @@ impl warp::reject::Reject for AuthError {}
 impl warp::Reply for AuthError {
     fn into_response(self) -> warp::reply::Response {
         let status = match self {
-            Self::NoTokenError | Self::UsernameTaken => StatusCode::OK,
+            Self::NoTokenError | Self::UsernameTaken => StatusCode::BAD_REQUEST,
             Self::DatabaseError | Self::RawDatabaseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::Unauthorized | Self::UserDoesntExist => StatusCode::UNAUTHORIZED,
             Self::WrongPassword | Self::FailedAuth => StatusCode::FORBIDDEN,


### PR DESCRIPTION
I discovered that when you try to change your username to one that already exists, the server responds with an HTTP 200 but an error message in the body. Rather than special case the UI code for this, the server should return non-200 for any errors.