### PR TITLE
Consolidate AuthError into DimError.

### DIFF
--- a/dim/src/routes/mod.rs
+++ b/dim/src/routes/mod.rs
@@ -34,12 +34,10 @@ pub mod global_filters {
     pub async fn handle_rejection(
         err: warp::reject::Rejection,
     ) -> Result<impl warp::Reply, warp::reject::Rejection> {
-        if let Some(e) = err.find::<errors::AuthError>() {
-            return Ok(e.clone().into_response());
-        } else if let Some(e) = err.find::<errors::DimError>() {
+        if let Some(e) = err.find::<errors::DimError>() {
             return Ok(e.clone().into_response());
         } else if err.find::<auth::JWTError>().is_some() {
-            return Ok(errors::DimError::AuthRequired.into_response());
+            return Ok(errors::DimError::Unauthenticated.into_response());
         } else if let Some(e) = err.find::<warp::filters::body::BodyDeserializeError>() {
             return Ok(errors::DimError::MissingFieldInBody {
                 description: e.source().unwrap().to_string(),


### PR DESCRIPTION
There was some duplication and confusing overlap in `DimError` and `AuthError` (and at least one case where a confusing HTTP status code was used—see #370), so I thought it made sense to fold `AuthError`'s variants into `DimError`.

Notable changes:

* `AuthRequired` variant renamed to `Unauthenticated` to distinguish more clearly from `Unauthorized`.
* `InvalidCredentials` variant used for all places where a login/password combination weren't valid. This avoids giving the user information to distinguish a bad password and a user not existing, which could be used for evil by a malicious user.