### PR TITLE
Improve "new library" file browser UX.

### DIFF
--- a/ui/src/Modals/NewLibrary/DirSelection.scss
+++ b/ui/src/Modals/NewLibrary/DirSelection.scss
@@ -7,15 +7,6 @@
     margin-top: 0.5em;
     justify-content: space-between;
     flex-wrap: wrap;
-
-    .actions {
-      display: flex;
-      gap: 1em;
-    }
-  }
-
-  .help {
-    margin-bottom: 0.5em;
   }
 
   .dirs-wrapper {
@@ -68,7 +59,7 @@
         width: 100%;
         display: flex;
 
-        // folder icon
+        // folder and right arrow icons
         svg {
           margin-right: 10px;
           fill: var(--tertiaryTextColor);
@@ -76,11 +67,19 @@
 
         // path name
         p {
-          margin: 0;
+          margin: 0 10px 0 0;
           user-select: none;
           overflow-wrap: break-word;
           overflow: hidden;
           word-break: break-all;
+        }
+
+        .arrowRight {
+          opacity: 0;
+        }
+
+        &:hover .arrowRight {
+          opacity: 1;
         }
       }
 
@@ -113,14 +112,27 @@
     margin-bottom: 0.5em;
     display: flex;
     align-items: center;
+    justify-content: space-between;
 
-    .btn.disabled {
-      opacity: 0;
+    .fileNavigation {
+      display: flex;
+      gap: 1em;
+      align-items: center;
+    }
+
+    .btn {
+      svg {
+        margin-right: 0.5em;
+      }
     }
 
     .current {
-      margin-left: 0.5em;
       font-family: "Roboto Condensed Regular", Arial;
+    }
+
+    .actions {
+      display: flex;
+      gap: 1em;
     }
   }
 }

--- a/ui/src/Modals/NewLibrary/DirSelection.scss
+++ b/ui/src/Modals/NewLibrary/DirSelection.scss
@@ -1,10 +1,10 @@
 .dirSelection {
   grid-area: dirSelection;
 
-  .header {
+  .details {
     display: flex;
     gap: 0.5em;
-    margin-bottom: 0.5em;
+    margin-top: 0.5em;
     justify-content: space-between;
     flex-wrap: wrap;
 
@@ -12,6 +12,10 @@
       display: flex;
       gap: 1em;
     }
+  }
+
+  .help {
+    margin-bottom: 0.5em;
   }
 
   .dirs-wrapper {
@@ -39,7 +43,7 @@
 
     .dir {
       display: grid;
-      grid-template-columns: 1fr 20px;
+      grid-template-columns: 25px 1fr;
       gap: 0.5em;
       padding: 0 0.5em;
       align-items: center;
@@ -51,20 +55,12 @@
         background: var(--modalTertiaryColor);
       }
 
-      &.selected-false .selectBox {
-        opacity: 0;
-      }
-
       &.selected-true .selectBox {
         background: var(--accentColor);
 
         svg {
           opacity: 1;
         }
-      }
-
-      &.selected-false:hover .selectBox {
-        opacity: 1;
       }
 
       .label {
@@ -101,7 +97,6 @@
         border-radius: 5px;
         border: solid 2px var(--accentColor);
         transition: background 150ms ease-in-out;
-        margin-right: 0.5em;
 
         svg {
           fill: var(--primaryTextColor);
@@ -115,9 +110,13 @@
   }
 
   .controls {
-    margin-top: 0.5em;
+    margin-bottom: 0.5em;
     display: flex;
     align-items: center;
+
+    .btn.disabled {
+      opacity: 0;
+    }
 
     .current {
       margin-left: 0.5em;

--- a/ui/src/Modals/NewLibrary/DirSelection.tsx
+++ b/ui/src/Modals/NewLibrary/DirSelection.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useGetDirectoriesQuery } from "../../api/v1/fileBrowser";
 import FolderIcon from "../../assets/Icons/Folder";
 import ArrowLeftIcon from "../../assets/Icons/ArrowLeft";
+import ArrowRightIcon from "../../assets/Icons/ArrowRight";
 import CheckIcon from "../../assets/Icons/Check";
 import Button from "../../Components/Misc/Button";
 
@@ -113,6 +114,9 @@ function DirSelection(props: Props) {
                   {count ? ` (${count} folders selected inside)` : ""}
                 </span>
               </p>
+              <div className="arrowRight">
+                <ArrowRightIcon />
+              </div>
             </div>
           </div>
         );
@@ -125,23 +129,13 @@ function DirSelection(props: Props) {
 
   return (
     <div className="dirSelection">
-      <div className="help">
-        <p>
-          Check folders containing media to include in the library. Click folder
-          names to list folders inside them.
-        </p>
-      </div>
       <div className="controls">
-        <Button onClick={goBack} disabled={current === ""}>
-          <ArrowLeftIcon />
-        </Button>
-        <p className="current">Currently viewing: {current || "/"}</p>
-      </div>
-      <div className="dirs-wrapper">
-        <div className="dirs">{dirs}</div>
-      </div>
-      <div className="details">
-        <div>Folders selected: {selectedFolders.length}</div>
+        <div className="fileNavigation">
+          <Button onClick={goBack} disabled={current === ""}>
+            <ArrowLeftIcon /> Back
+          </Button>
+          <p className="current">{current || "/"}</p>
+        </div>
         <div className="actions">
           <Button
             disabled={selectedFolders.length <= 0}
@@ -158,6 +152,12 @@ function DirSelection(props: Props) {
             Select all
           </Button>
         </div>
+      </div>
+      <div className="dirs-wrapper">
+        <div className="dirs">{dirs}</div>
+      </div>
+      <div className="details">
+        <div>Folders selected: {selectedFolders.length}</div>
       </div>
     </div>
   );

--- a/ui/src/Modals/NewLibrary/DirSelection.tsx
+++ b/ui/src/Modals/NewLibrary/DirSelection.tsx
@@ -102,6 +102,9 @@ function DirSelection(props: Props) {
             key={i}
             className={`dir selected-${selectedFolders.includes(dir)}`}
           >
+            <div className="selectBox" onClick={() => selectFolder(dir)}>
+              <CheckIcon />
+            </div>
             <div className="label" onClick={() => select(dir)}>
               <FolderIcon />
               <p>
@@ -110,9 +113,6 @@ function DirSelection(props: Props) {
                   {count ? ` (${count} folders selected inside)` : ""}
                 </span>
               </p>
-            </div>
-            <div className="selectBox" onClick={() => selectFolder(dir)}>
-              <CheckIcon />
             </div>
           </div>
         );
@@ -125,8 +125,23 @@ function DirSelection(props: Props) {
 
   return (
     <div className="dirSelection">
-      <div className="header">
-        <h4>Select folders containing media ({selectedFolders.length})</h4>
+      <div className="help">
+        <p>
+          Check folders containing media to include in the library. Click folder
+          names to list folders inside them.
+        </p>
+      </div>
+      <div className="controls">
+        <Button onClick={goBack} disabled={current === ""}>
+          <ArrowLeftIcon />
+        </Button>
+        <p className="current">Currently viewing: {current || "/"}</p>
+      </div>
+      <div className="dirs-wrapper">
+        <div className="dirs">{dirs}</div>
+      </div>
+      <div className="details">
+        <div>Folders selected: {selectedFolders.length}</div>
         <div className="actions">
           <Button
             disabled={selectedFolders.length <= 0}
@@ -143,15 +158,6 @@ function DirSelection(props: Props) {
             Select all
           </Button>
         </div>
-      </div>
-      <div className="dirs-wrapper">
-        <div className="dirs">{dirs}</div>
-      </div>
-      <div className="controls">
-        <Button onClick={goBack} disabled={current === ""}>
-          <ArrowLeftIcon />
-        </Button>
-        <p className="current">{current}</p>
       </div>
     </div>
   );

--- a/ui/src/assets/Icons/ArrowRight.tsx
+++ b/ui/src/assets/Icons/ArrowRight.tsx
@@ -1,0 +1,16 @@
+/*
+  Font Awesome Free 5.15.3 by @fontawesome
+  https://fontawesome.com License - https://fontawesome.com/license/free
+  (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+*/
+
+const ArrowRightIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+    <path
+      fill="currentColor"
+      d="M438.6 278.6l-160 160C272.4 444.9 264.2 448 256 448s-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L338.8 288H32C14.33 288 .0016 273.7 .0016 256S14.33 224 32 224h306.8l-105.4-105.4c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l160 160C451.1 245.9 451.1 266.1 438.6 278.6z"
+    />
+  </svg>
+);
+
+export default ArrowRightIcon;


### PR DESCRIPTION
When I first tried Dim, I had a hard time figuring out how to add media, because the check boxes that you need to click to select a folder in the file browser don't appear until you hover over them, so I didn't realize there even *were* check boxes. I kept clicking on folder names, which just shows their contents. I saw a comment on reddit from a user who had the same confusion I had. This PR rearranges the UI of the "new library" file browser to improve the user experience here.

Here are some screen shots comparing the before and after with some notes about what's changed.

## Before

### Initial state

* The prompt "select folders containing media" is combined with the number of folders that are selected, with no explanation of what the number in parentheses means.
* The check boxes are not visible.
* The current path is not shown.
* The back button is hard to notice at the bottom.

<img width="585" alt="old_file_browser_init" src="https://user-images.githubusercontent.com/122457/148733266-f72e4344-be44-4c98-8640-51aa5274cfa2.png">

### Within a subfolder with a folder checked

* Only after hovering over a check box and clicking it does it stay visible.
* The check boxes are aligned to the right and it can be a little difficult to see which row each check box corresponds to.

<img width="582" alt="old_file_browser_selection" src="https://user-images.githubusercontent.com/122457/148733269-e675a0bc-62c4-4758-b428-0874f346b80b.png">

## After

### Initial state

* Help text is added to explain the function of clicking a check box vs. clicking a folder name.
* The back button doesn't appear, because you can't go back from the root.
* The current path is shown and the label clarifies that the directories shown are being *viewed* but are not selected.
* All the unchecked check boxes are visible and aligned to the left where it's easy to see which row each one corresponds to.
* The number of folders currently selected has a dedicated label explaining what the number means.
* The number of folders selected and the toggle actions are moved below the browser.

<img width="584" alt="new_file_browser_init" src="https://user-images.githubusercontent.com/122457/148733284-6fdb11fe-aae2-46da-b377-ff55b613a0cd.png">

### Within a subfolder with a folder checked

* The back button appears at the top, where a user is likely to expect it based on its default position in web browsers and operating system file browsers.
* The checked and unchecked check boxes and their corresponding items are clearly distinguishable.

<img width="582" alt="new_file_browser_selection" src="https://user-images.githubusercontent.com/122457/148733286-488ea03f-f3b3-4ca8-b678-4c4f83c23e21.png">