### PR TITLE
Set baseUrl to allow absolute imports.

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -6,6 +6,7 @@
       "dom.iterable",
       "esnext"
     ],
+    "baseUrl": "src",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Setting this option in `tsconfig.json` allows modules to import other modules without using `../` to walk the directory tree. For example, in `src/Components/Sidebar/Index.tsx`:

```ts
import { useAppDispatch } from "../../hooks/store";
```

can now be changed to:

```ts
import { useAppDispatch } from "hooks/store";
```

This is easier to read and doesn't need to be modified if the file that is doing the import is moved to another place in the tree.

Imports beginning with `./` can and should still be used to import something deeper in the tree than the module doing the import. For example, in `src/Components/Sidebar/Index.tsx`, this import should remain as it is:

```ts
import Profile from "./Profile/Index";
```