### PR TITLE
Change ffpath to return String to avoid leaking memory

### DIFF
--- a/dim/src/main.rs
+++ b/dim/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let config_path = args
         .config
         .map(|x| x.to_string_lossy().to_string())
-        .unwrap_or(dim::utils::ffpath("config/config.toml").to_string());
+        .unwrap_or(dim::utils::ffpath("config/config.toml"));
 
     // initialize global settings.
     dim::init_global_settings(Some(config_path)).expect("Failed to initialize global settings.");

--- a/dim/src/routes/settings.rs
+++ b/dim/src/routes/settings.rs
@@ -56,7 +56,7 @@ impl Default for GlobalSettings {
                     }
                 }
             },
-            metadata_dir: ffpath("config/metadata").into(),
+            metadata_dir: ffpath("config/metadata"),
             quiet_boot: false,
             disable_auth: false,
             verbose: false,
@@ -75,7 +75,7 @@ pub fn get_global_settings() -> GlobalSettings {
 }
 
 pub fn init_global_settings(path: Option<String>) -> Result<(), Box<dyn Error>> {
-    let path = path.unwrap_or(ffpath("config/config.toml").into());
+    let path = path.unwrap_or(ffpath("config/config.toml"));
     let _ = SETTINGS_PATH.set(path.clone());
     let mut content = String::new();
 
@@ -100,7 +100,7 @@ pub fn set_global_settings(settings: GlobalSettings) -> Result<(), Box<dyn Error
     let path = SETTINGS_PATH
         .get()
         .cloned()
-        .unwrap_or(ffpath("config/config.toml").into());
+        .unwrap_or(ffpath("config/config.toml"));
 
     {
         let mut lock = GLOBAL_SETTINGS.lock().unwrap();

--- a/dim/src/streaming/mod.rs
+++ b/dim/src/streaming/mod.rs
@@ -8,8 +8,8 @@ use crate::utils::ffpath;
 
 lazy_static::lazy_static! {
     pub static ref STREAMING_SESSION: Arc<RwLock<HashMap<String, HashMap<String, String>>>> = Arc::new(RwLock::new(HashMap::new()));
-    pub static ref FFMPEG_BIN: &'static str = ffpath("utils/ffmpeg");
-    pub static ref FFPROBE_BIN: &'static str = ffpath("utils/ffprobe");
+    pub static ref FFMPEG_BIN: &'static str = Box::leak(ffpath("utils/ffmpeg").into_boxed_str());
+    pub static ref FFPROBE_BIN: &'static str = Box::leak(ffpath("utils/ffprobe").into_boxed_str());
 }
 
 use std::process::Command;

--- a/dim/src/utils.rs
+++ b/dim/src/utils.rs
@@ -458,17 +458,17 @@ pub fn ts_to_xml(t: u64) -> String {
 }
 
 #[cfg(not(debug_assertions))]
-pub fn ffpath(bin: impl AsRef<str>) -> &'static str {
+pub fn ffpath(bin: impl AsRef<str>) -> String {
     let mut path = std::env::current_exe().expect("Failed to grab path to the `dim` binary.");
     path.pop(); // remove the dim bin to get the dir of `dim`
     path.push(bin.as_ref());
 
-    Box::leak(path.to_string_lossy().to_string().into_boxed_str())
+    path.to_string_lossy().to_string()
 }
 
 #[cfg(debug_assertions)]
-pub fn ffpath(bin: impl AsRef<str>) -> &'static str {
-    Box::leak(bin.as_ref().to_string().into_boxed_str())
+pub fn ffpath(bin: impl AsRef<str>) -> String {
+    bin.as_ref().to_string()
 }
 
 pub fn codec_pretty(codec: &str) -> String {


### PR DESCRIPTION
It's not a huge issue, but I think it is possible to waste memory after repeated changes to global settings.