### PR TITLE
Fix runtime error regarding player context

### DIFF
--- a/ui/src/Pages/Dashboard/Banners/Image.tsx
+++ b/ui/src/Pages/Dashboard/Banners/Image.tsx
@@ -18,9 +18,7 @@ const BannerImage = (props: Props) => (
         error: boolean;
         setErr: Dispatch<SetStateAction<boolean>>;
       }) => {
-        if (error) {
-          return <div className="placeholder" />;
-        } else if (imageSrc != null) {
+        if (imageSrc != null) {
           return (
             <img
               src={imageSrc}
@@ -30,6 +28,8 @@ const BannerImage = (props: Props) => (
             />
           );
         }
+
+        return <div className="placeholder" />;
       }}
     </ImageLoad>
   </div>

--- a/ui/src/Pages/VideoPlayer/Context.ts
+++ b/ui/src/Pages/VideoPlayer/Context.ts
@@ -5,6 +5,7 @@ interface VideoPlayerContext {
   videoPlayer: React.MutableRefObject<HTMLDivElement | null>;
   overlay: HTMLDivElement | null;
   seekTo: (newTime: number) => void;
+  player: dashjs.MediaPlayerClass;
 }
 
 // Intentionally naming the variable the same as the type.

--- a/ui/src/Pages/VideoPlayer/Controls/Actions/PlayPause.jsx
+++ b/ui/src/Pages/VideoPlayer/Controls/Actions/PlayPause.jsx
@@ -1,17 +1,20 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import PlayIcon from "../../../../assets/Icons/Play";
 import PauseIcon from "../../../../assets/Icons/Pause";
+
+import { VideoPlayerContext } from "../../Context";
 
 import { updateVideo } from "../../../../actions/video";
 
 function VideoActionPlayPause() {
   const dispatch = useDispatch();
 
-  const { video, player } = useSelector((store) => ({
+  const { player } = useContext(VideoPlayerContext);
+
+  const { video } = useSelector((store) => ({
     video: store.video,
-    player: store.video.player,
   }));
 
   const play = useCallback(() => {

--- a/ui/src/Pages/VideoPlayer/Controls/Actions/Volume.jsx
+++ b/ui/src/Pages/VideoPlayer/Controls/Actions/Volume.jsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { VideoPlayerContext } from "../../Context";
 
 import VolumeUpIcon from "../../../../assets/Icons/VolumeUp";
 import VolumeMuteIcon from "../../../../assets/Icons/VolumeMute";
@@ -8,10 +9,10 @@ import { updateVideo } from "../../../../actions/video";
 
 function VideoActionVolume() {
   const dispatch = useDispatch();
+  const { player } = useContext(VideoPlayerContext);
 
-  const { video, player } = useSelector((store) => ({
+  const { video } = useSelector((store) => ({
     video: store.video,
-    player: store.video.player,
   }));
 
   const volSliderRef = useRef(null);

--- a/ui/src/Pages/VideoPlayer/Controls/SeekBar.jsx
+++ b/ui/src/Pages/VideoPlayer/Controls/SeekBar.jsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import SeekingTo from "./SeekingTo";
+import { VideoPlayerContext } from "../Context";
 
 import "./SeekBar.scss";
 import { updateVideo } from "../../../actions/video";
@@ -9,10 +10,11 @@ import { updateVideo } from "../../../actions/video";
 function VideoSeekBar(props) {
   const dispatch = useDispatch();
 
-  const { auth, video, player } = useSelector((store) => ({
+  const { player } = useContext(VideoPlayerContext);
+
+  const { auth, video } = useSelector((store) => ({
     auth: store.auth,
     video: store.video,
-    player: store.video.player,
   }));
 
   const seekBar = useRef(null);

--- a/ui/src/Pages/VideoPlayer/Controls/SeekingTo.jsx
+++ b/ui/src/Pages/VideoPlayer/Controls/SeekingTo.jsx
@@ -1,13 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useSelector } from "react-redux";
+import { useCallback, useEffect, useRef, useState, useContext } from "react";
 import { formatHHMMSS } from "../../../Helpers/utils";
+import { VideoPlayerContext } from "../Context";
 
 import "./SeekingTo.scss";
 
 function SeekingTo(props) {
-  const { player } = useSelector((store) => ({
-    player: store.video.player,
-  }));
+  const { player } = useContext(VideoPlayerContext);
 
   const seekingToDiv = useRef(null);
 

--- a/ui/src/Pages/VideoPlayer/Events.jsx
+++ b/ui/src/Pages/VideoPlayer/Events.jsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { MediaPlayer } from "dashjs";
+
+import { VideoPlayerContext } from "./Context";
 
 import {
   setManifestState,
@@ -10,10 +12,10 @@ import {
 
 function VideoEvents() {
   const dispatch = useDispatch();
+  const { player } = useContext(VideoPlayerContext);
 
-  const { video, player } = useSelector((store) => ({
+  const { video } = useSelector((store) => ({
     video: store.video,
-    player: store.video.player,
   }));
 
   const eManifestLoad = useCallback(() => {

--- a/ui/src/Pages/VideoPlayer/Index.jsx
+++ b/ui/src/Pages/VideoPlayer/Index.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router";
 import { useHistory } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
@@ -34,26 +34,18 @@ function VideoPlayer() {
   const params = useParams();
   const dispatch = useDispatch();
   const history = useHistory();
+  const [player, setPlayer] = useState();
 
-  const {
-    error,
-    manifest,
-    player,
-    audioTracks,
-    videoTracks,
-    video,
-    auth,
-    settings,
-  } = useSelector((store) => ({
-    auth: store.auth,
-    video: store.video,
-    player: store.video.player,
-    manifest: store.video.manifest,
-    videoTracks: store.video.tracks.video,
-    audioTracks: store.video.tracks.audio,
-    error: store.video.error,
-    settings: store.settings,
-  }));
+  const { error, manifest, audioTracks, videoTracks, video, auth, settings } =
+    useSelector((store) => ({
+      auth: store.auth,
+      video: store.video,
+      manifest: store.video.manifest,
+      videoTracks: store.video.tracks.video,
+      audioTracks: store.video.tracks.audio,
+      error: store.video.error,
+      settings: store.settings,
+    }));
 
   const videoPlayer = useRef(null);
   const overlay = useRef(null);
@@ -226,11 +218,7 @@ function VideoPlayer() {
     mediaPlayer.initialize(videoRef.current, url, true);
     mediaPlayer.setCustomInitialTrackSelectionFunction(getInitialTrack);
 
-    dispatch(
-      updateVideo({
-        player: mediaPlayer,
-      })
-    );
+    setPlayer(mediaPlayer);
 
     return () => {
       dispatch(clearVideoData());
@@ -250,6 +238,7 @@ function VideoPlayer() {
     manifest.virtual.loaded,
     video.gid,
     videoTracks.list,
+    setPlayer,
   ]);
 
   const seekTo = useCallback(
@@ -276,6 +265,7 @@ function VideoPlayer() {
     videoPlayer,
     overlay: overlay.current,
     seekTo,
+    player,
   };
 
   const showNextVideoAfter = (media && media.chapters?.credits) || 0;

--- a/ui/src/Pages/VideoPlayer/Menus/Settings.jsx
+++ b/ui/src/Pages/VideoPlayer/Menus/Settings.jsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { updateVideo, updateTrack } from "../../../actions/video";
+
+import { VideoPlayerContext } from "../Context";
 
 import ArrowLeftIcon from "../../../assets/Icons/ArrowLeft";
 import ChevronRightIcon from "../../../assets/Icons/ChevronRight";
@@ -9,8 +11,9 @@ import ChevronRightIcon from "../../../assets/Icons/ChevronRight";
 function VideoMenuSettings() {
   const dispatch = useDispatch();
 
-  const { player, video } = useSelector((store) => ({
-    player: store.video.player,
+  const { player } = useContext(VideoPlayerContext);
+
+  const { video } = useSelector((store) => ({
     video: store.video,
   }));
 


### PR DESCRIPTION
The `MediaPlayer` instance obtained from dash.js was being saved in our redux store but the instance isn't serialazible. This PR fixes this issue by sharing the `MediaPlayer` instance through `VIdeoPlayerContext` instead of the redux store.

This PR also fixes a TS error where `ImageLoad` would return `undefined` when there's no loading error but the URL is also null.