### PR TITLE
Add feature system_ff

### DIFF
--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -15,6 +15,7 @@ vaapi = ["nightfall/vaapi"]
 embed_ui = []
 postgres = ["database/postgres"]
 sqlite = ["database/sqlite"]
+system_ff = ["which"]
 
 [dependencies]
 serde = { version = "^1.0.125", default-features = false, features = [
@@ -73,6 +74,7 @@ tracing-subscriber = { version = "0.3.1", features = [
 tracing-appender = "0.2.0"
 dia-i18n = "0.9.0"
 console-subscriber = "0.1.0"
+which = { version = "4.2.4", optional = true }
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -15,7 +15,6 @@ vaapi = ["nightfall/vaapi"]
 embed_ui = []
 postgres = ["database/postgres"]
 sqlite = ["database/sqlite"]
-system_ff = ["which"]
 
 [dependencies]
 serde = { version = "^1.0.125", default-features = false, features = [
@@ -74,7 +73,7 @@ tracing-subscriber = { version = "0.3.1", features = [
 tracing-appender = "0.2.0"
 dia-i18n = "0.9.0"
 console-subscriber = "0.1.0"
-which = { version = "4.2.4", optional = true }
+which = "4.2.4"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/src/main.rs
+++ b/dim/src/main.rs
@@ -20,6 +20,8 @@ use structopt::StructOpt;
 struct Args {
     #[structopt(short, long, parse(from_os_str))]
     config: Option<PathBuf>,
+    #[structopt(long)]
+    use_system_ffmpeg: bool,
 }
 
 fn main() {
@@ -60,7 +62,7 @@ fn main() {
     setup_logging(global_settings.verbose);
 
     {
-        let failed = streaming::ffcheck()
+        let failed = streaming::ffcheck(args.use_system_ffmpeg)
             .into_iter()
             .fold(false, |failed, item| match item {
                 Ok(stdout) => {
@@ -89,7 +91,7 @@ fn main() {
         let stream_manager = nightfall::StateManager::new(
             &mut Tokio::Global,
             global_settings.cache_dir.clone(),
-            crate::streaming::FFMPEG_BIN.to_string(),
+            crate::streaming::FFMPEG_BIN.to_string()
         );
 
         let stream_manager_clone = stream_manager.clone();

--- a/dim/src/scanners/base.rs
+++ b/dim/src/scanners/base.rs
@@ -20,8 +20,8 @@ use crate::core::EventTx;
 use crate::scanners::movie::MovieMatcher;
 use crate::scanners::tmdb::Tmdb;
 use crate::scanners::tv_show::TvShowMatcher;
-use crate::streaming::ffprobe::FFProbeCtx;
 use crate::streaming::FFPROBE_BIN;
+use crate::streaming::ffprobe::FFProbeCtx;
 
 use super::ApiMedia;
 

--- a/dim/src/streaming/mod.rs
+++ b/dim/src/streaming/mod.rs
@@ -1,5 +1,6 @@
 pub mod ffprobe;
 
+use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -58,19 +59,19 @@ pub fn ffcheck(use_system_ffmpeg: bool) -> Vec<Result<Box<str>, String>> {
 }
 
 fn find_ff_path(use_system_ffmpeg: bool) -> (String, String) {
-    if use_system_ffmpeg {
-        let ffmpeg = which::which("ffmpeg");
-        let ffprobe = which::which("ffprobe");
-        if let Ok(ffmpeg) = ffmpeg {
-            if let Ok(ffprobe) = ffprobe {
-                if let Some(ffmpeg) = ffmpeg.to_str() {
-                    if let Some(ffprobe) = ffprobe.to_str() {
-                        info!("Using system ffmpeg and ffprobe!");
-                        return (ffmpeg.to_string(), ffprobe.to_string());
-                    }
-                }
-            }
+    fn find_system_ff(use_system_ffmpeg: bool) -> Option<(String, String)> {
+        if use_system_ffmpeg {
+            let ffmpeg = which::which("ffmpeg").ok()?.to_str()?.to_string();
+            let ffprobe = which::which("ffprobe").ok()?.to_str()?.to_string();
+            return Some((ffmpeg, ffprobe));
         }
+
+        None
+    }
+
+    if let Some((ffmpeg, ffprobe)) = find_system_ff(use_system_ffmpeg) {
+        info!("Using system ffmpeg and ffprobe!");
+        return (ffmpeg, ffprobe);
     }
     info!("Using non-system ffmpeg and ffprobe!");
 

--- a/dim/src/streaming/mod.rs
+++ b/dim/src/streaming/mod.rs
@@ -6,6 +6,8 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use tracing::info;
+
 use crate::utils::ffpath;
 
 lazy_static::lazy_static! {
@@ -63,12 +65,14 @@ fn find_ff_path(use_system_ffmpeg: bool) -> (String, String) {
             if let Ok(ffprobe) = ffprobe {
                 if let Some(ffmpeg) = ffmpeg.to_str() {
                     if let Some(ffprobe) = ffprobe.to_str() {
+                        info!("Using system ffmpeg and ffprobe!");
                         return (ffmpeg.to_string(), ffprobe.to_string());
                     }
                 }
             }
         }
     }
+    info!("Using non-system ffmpeg and ffprobe!");
 
     (String::from("utils/ffmpeg"), String::from("utils/ffprobe"))
 }

--- a/dim/src/streaming/mod.rs
+++ b/dim/src/streaming/mod.rs
@@ -8,8 +8,9 @@ use crate::utils::ffpath;
 
 lazy_static::lazy_static! {
     pub static ref STREAMING_SESSION: Arc<RwLock<HashMap<String, HashMap<String, String>>>> = Arc::new(RwLock::new(HashMap::new()));
-    pub static ref FFMPEG_BIN: &'static str = Box::leak(ffpath("utils/ffmpeg").into_boxed_str());
-    pub static ref FFPROBE_BIN: &'static str = Box::leak(ffpath("utils/ffprobe").into_boxed_str());
+    pub static ref FF_PATH: (String, String) = find_ff_path();
+    pub static ref FFMPEG_BIN: &'static str = Box::leak(ffpath(FF_PATH.0.as_str()).into_boxed_str());
+    pub static ref FFPROBE_BIN: &'static str = Box::leak(ffpath(FF_PATH.1.as_str()).into_boxed_str());
 }
 
 use std::process::Command;
@@ -47,6 +48,25 @@ pub fn ffcheck() -> Vec<Result<Box<str>, &'static str>> {
     }
 
     results
+}
+
+#[cfg(feature = "system_ff")]
+fn find_ff_path() -> (String, String) {
+    let ffmpeg_bin = which::which("ffmpeg")
+        .expect("Could not find ffmpeg in system!")
+        .display()
+        .to_string();
+    let ffprobe_bin = which::which("ffprobe")
+        .expect("Could not find ffprobe in system!")
+        .display()
+        .to_string();
+
+    (ffmpeg_bin, ffprobe_bin)
+}
+
+#[cfg(not(feature = "system_ff"))]
+fn find_ff_path() -> (String, String) {
+    (String::from("utils/ffmpeg"), String::from("utils/ffprobe"))
 }
 
 #[derive(Clone, Copy)]

--- a/dim/src/utils.rs
+++ b/dim/src/utils.rs
@@ -459,15 +459,11 @@ pub fn ts_to_xml(t: u64) -> String {
 
 #[cfg(not(debug_assertions))]
 pub fn ffpath(bin: impl AsRef<str>) -> String {
-    if !cfg!(feature = "system_ff") {
-        let mut path = std::env::current_exe().expect("Failed to grab path to the `dim` binary.");
-        path.pop(); // remove the dim bin to get the dir of `dim`
-        path.push(bin.as_ref());
-    
-        path.to_string_lossy().to_string()
-    } else {
-        bin.as_ref().to_string()
-    }
+    let mut path = std::env::current_exe().expect("Failed to grab path to the `dim` binary.");
+    path.pop(); // remove the dim bin to get the dir of `dim`
+    path.push(bin.as_ref());
+
+    path.to_string_lossy().to_string()
 }
 
 #[cfg(debug_assertions)]

--- a/dim/src/utils.rs
+++ b/dim/src/utils.rs
@@ -459,11 +459,15 @@ pub fn ts_to_xml(t: u64) -> String {
 
 #[cfg(not(debug_assertions))]
 pub fn ffpath(bin: impl AsRef<str>) -> String {
-    let mut path = std::env::current_exe().expect("Failed to grab path to the `dim` binary.");
-    path.pop(); // remove the dim bin to get the dir of `dim`
-    path.push(bin.as_ref());
-
-    path.to_string_lossy().to_string()
+    if !cfg!(feature = "system_ff") {
+        let mut path = std::env::current_exe().expect("Failed to grab path to the `dim` binary.");
+        path.pop(); // remove the dim bin to get the dir of `dim`
+        path.push(bin.as_ref());
+    
+        path.to_string_lossy().to_string()
+    } else {
+        bin.as_ref().to_string()
+    }
 }
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
This feature will look for ffmpeg and ffprobe on the system, and will report an error if they are not present, which is necessary for distribution software maintenance, use `--features system_ff` to turn on this feature