### PR TITLE
Convert JS modules with five imports to TS.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,7 @@
   "name": "dim",
   "dependencies": {
     "@reduxjs/toolkit": "^1.7.1",
+    "@types/react-modal": "^3.13.1",
     "dashjs": "=4.1.0",
     "libass-wasm": "https://github.com/jellyfin/JavascriptSubtitlesOctopus",
     "node-sass": "^6.0.0",

--- a/ui/src/Components/Sidebar/Library.tsx
+++ b/ui/src/Components/Sidebar/Library.tsx
@@ -1,12 +1,18 @@
 import { NavLink } from "react-router-dom";
 
-import FilmIcon from "../../assets/Icons/Film";
-import TvIcon from "../../assets/Icons/TvIcon";
-import BarLoad from "../Load/Bar";
-import { useSelector } from "react-redux";
+import { useAppSelector } from "hooks/store";
+import FilmIcon from "assets/Icons/Film";
+import TvIcon from "assets/Icons/TvIcon";
+import BarLoad from "Components/Load/Bar";
 
-function Library(props) {
-  const scanning = useSelector((store) => store.library.scanning);
+interface Props {
+  id: string;
+  media_type: string;
+  name: string;
+}
+
+function Library(props: Props) {
+  const scanning = useAppSelector((store) => store.library.scanning);
   const { id, media_type, name } = props;
 
   return (

--- a/ui/src/Components/Sidebar/Toggle.tsx
+++ b/ui/src/Components/Sidebar/Toggle.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
-import DimLogo from "../../assets/DimLogo";
-import AngleLeftIcon from "../../assets/Icons/AngleLeft";
+import DimLogo from "assets/DimLogo";
+import AngleLeftIcon from "assets/Icons/AngleLeft";
 
 import "./Toggle.scss";
 
-function Toggle(props) {
+interface Props {
+  sidebar: React.MutableRefObject<HTMLElement | null>;
+}
+
+function Toggle(props: Props) {
   const [defaultChecked, setDefaultChecked] = useState(false);
   const [visible, setVisible] = useState(true);
 
@@ -22,24 +26,35 @@ function Toggle(props) {
       if (withAnimation) {
         main.style.transition = "margin .3s ease-in-out";
 
-        visible
-          ? (props.sidebar.current.style.animation =
-              "hideSidebar .3s ease-in-out forwards")
-          : (props.sidebar.current.style.animation =
-              "showSidebar .3s ease-in-out forwards");
+        if (props.sidebar.current) {
+          if (visible) {
+            props.sidebar.current.style.animation =
+              "hideSidebar .3s ease-in-out forwards";
+          } else {
+            props.sidebar.current.style.animation =
+              "showSidebar .3s ease-in-out forwards";
+          }
+        }
 
-        localStorage.setItem("defaultSidebarVisible", !visible);
+        localStorage.setItem("defaultSidebarVisible", (!visible).toString());
       } else {
         main.style.transition = "";
-        props.sidebar.current.style.animation = "";
 
-        visible
-          ? (props.sidebar.current.style.transform = "translateX(-100%)")
-          : (props.sidebar.current.style.transform = "translateX(0)");
+        if (props.sidebar.current) {
+          props.sidebar.current.style.animation = "";
+
+          if (visible) {
+            props.sidebar.current.style.transform = "translateX(-100%)";
+          } else {
+            props.sidebar.current.style.transform = "translateX(0)";
+          }
+        }
       }
 
-      props.sidebar.current.classList.toggle("hide", visible);
-      props.sidebar.current.classList.toggle("show", !visible);
+      if (props.sidebar.current) {
+        props.sidebar.current.classList.toggle("hide", visible);
+        props.sidebar.current.classList.toggle("show", !visible);
+      }
 
       main.classList.toggle("full", visible);
       main.classList.toggle("shrunk", !visible);

--- a/ui/src/Controllers/Theme.tsx
+++ b/ui/src/Controllers/Theme.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
-import { useSelector } from "react-redux";
 
-import DefaultTheme from "../Themes/Default";
-import BlindTheme from "../Themes/Blind";
-import LightsOff from "../Themes/LightsOff";
+import { useAppSelector } from "hooks/store";
+import DefaultTheme from "Themes/Default";
+import BlindTheme from "Themes/Blind";
+import LightsOff from "Themes/LightsOff";
 
 function ThemeController() {
-  const userSettings = useSelector((store) => store.settings.userSettings);
+  const userSettings = useAppSelector((store) => store.settings.userSettings);
 
   useEffect(() => {
     switch (userSettings.data.theme) {
@@ -14,7 +14,7 @@ function ThemeController() {
         for (const prop in DefaultTheme) {
           document.documentElement.style.setProperty(
             `--${prop}`,
-            `${DefaultTheme[prop]}`
+            `${DefaultTheme[prop as keyof typeof DefaultTheme]}`
           );
         }
         break;
@@ -22,7 +22,7 @@ function ThemeController() {
         for (const prop in BlindTheme) {
           document.documentElement.style.setProperty(
             `--${prop}`,
-            `${BlindTheme[prop]}`
+            `${BlindTheme[prop as keyof typeof BlindTheme]}`
           );
         }
         break;
@@ -30,7 +30,7 @@ function ThemeController() {
         for (const prop in LightsOff) {
           document.documentElement.style.setProperty(
             `--${prop}`,
-            `${LightsOff[prop]}`
+            `${LightsOff[prop as keyof typeof LightsOff]}`
           );
         }
         break;

--- a/ui/src/Modals/ConfirmationBox.tsx
+++ b/ui/src/Modals/ConfirmationBox.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback } from "react";
+import React, { useCallback } from "react";
 
 import ModalBox from "./Index";
 
@@ -10,9 +10,10 @@ interface Props {
   msg: string;
   cancelText: string;
   confirmText: string;
+  children?: React.ReactElement;
 }
 
-export const ConfirmationBox = (props: PropsWithChildren<Props>) => {
+export const ConfirmationBox = (props: Props) => {
   const { action } = props;
 
   const confirmAction = useCallback(

--- a/ui/src/Modals/Index.tsx
+++ b/ui/src/Modals/Index.tsx
@@ -1,13 +1,19 @@
-import { cloneElement, useCallback, useEffect, useState } from "react";
+import React, { cloneElement, useCallback, useEffect, useState } from "react";
 import Modal from "react-modal";
 
 import "./Index.scss";
+
+interface Props {
+  activatingComponent?: React.ReactElement;
+  id?: string;
+  children: (close: () => void) => React.ReactNode;
+}
 
 /*
   This contains the core logic for a modal e.g. open/close etc
   This is to only be used by components that intend to be rendered in a modal
 */
-const ModalBox = (props) => {
+const ModalBox = (props: Props) => {
   const [visible, setVisible] = useState(!props.activatingComponent);
 
   // prevent scrolling behind Modal
@@ -19,11 +25,7 @@ const ModalBox = (props) => {
 
   const close = useCallback(() => {
     setVisible(false);
-
-    if (props.cleanUp) {
-      props.cleanUp();
-    }
-  }, [props]);
+  }, []);
 
   const open = useCallback(() => {
     setVisible(true);

--- a/ui/src/Modals/InputConfirmationBox.tsx
+++ b/ui/src/Modals/InputConfirmationBox.tsx
@@ -18,9 +18,10 @@ interface Props {
   type: string;
   cancelText: string;
   confirmText: string;
+  children?: React.ReactElement;
 }
 
-export const InputConfirmationBox = (props: React.PropsWithChildren<Props>) => {
+export const InputConfirmationBox = (props: Props) => {
   const { action } = props;
 
   const confirmAction = useCallback(

--- a/ui/src/Modals/SelectMediaFile/Activators/PlayButton.tsx
+++ b/ui/src/Modals/SelectMediaFile/Activators/PlayButton.tsx
@@ -1,10 +1,20 @@
 import { useCallback, useContext } from "react";
 
-import Button from "../../../Components/Misc/Button";
-import PlayIcon from "../../../assets/Icons/Play";
+import Button from "Components/Misc/Button";
+import PlayIcon from "assets/Icons/Play";
 import { SelectMediaFileContext } from "../Context";
 
-function SelectMediaFilePlayButton(props) {
+interface Props {
+  progress: number;
+  seasonep: {
+    episode: number;
+    season: number;
+  };
+  label?: string;
+  hideIcon?: boolean;
+}
+
+function SelectMediaFilePlayButton(props: Props) {
   const { setClicked, currentID } = useContext(SelectMediaFileContext);
   const { progress, seasonep, label, hideIcon } = props;
 

--- a/ui/src/Modals/SelectMediaFile/Context.js
+++ b/ui/src/Modals/SelectMediaFile/Context.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const SelectMediaFileContext = createContext(null);

--- a/ui/src/Modals/SelectMediaFile/Context.ts
+++ b/ui/src/Modals/SelectMediaFile/Context.ts
@@ -1,0 +1,18 @@
+import { createContext } from "react";
+
+export interface SelectMediaFileContext {
+  open: () => void;
+  close: () => void;
+  currentID?: number | null;
+  setClicked: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+// Intentionally naming the variable the same as the type.
+// See: https://github.com/typescript-eslint/typescript-eslint/issues/2585
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SelectMediaFileContext = createContext<SelectMediaFileContext>({
+  open: () => {},
+  close: () => {},
+  currentID: null,
+  setClicked: () => {},
+});

--- a/ui/src/Pages/Auth/LoginBtn.tsx
+++ b/ui/src/Pages/Auth/LoginBtn.tsx
@@ -1,10 +1,19 @@
-import { useCallback, useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { authenticate } from "../../actions/auth.js";
+import React, { useCallback, useEffect } from "react";
 
-function LoginBtn(props) {
-  const dispatch = useDispatch();
-  const auth = useSelector((store) => store.auth);
+import { useAppDispatch, useAppSelector } from "hooks/store";
+import { authenticate } from "actions/auth.js";
+
+interface Props {
+  credentials: [string, string];
+  error: [
+    React.Dispatch<React.SetStateAction<string>>,
+    React.Dispatch<React.SetStateAction<string>>
+  ];
+}
+
+function LoginBtn(props: Props) {
+  const dispatch = useAppDispatch();
+  const auth = useAppSelector((store) => store.auth);
 
   const { credentials, error } = props;
 
@@ -12,7 +21,7 @@ function LoginBtn(props) {
   const [setUsernameErr, setPasswordErr] = error;
 
   const authorize = useCallback(async () => {
-    if (auth.logging_in) return;
+    if (auth.login.logging_in) return;
 
     const allowedChars = /^[a-zA-Z0-9_.-]*$/;
 
@@ -36,7 +45,7 @@ function LoginBtn(props) {
 
     dispatch(authenticate(username, password));
   }, [
-    auth.logging_in,
+    auth.login.logging_in,
     dispatch,
     password,
     setPasswordErr,
@@ -62,7 +71,7 @@ function LoginBtn(props) {
   }, [onKeyDown]);
 
   return (
-    <button className={`${auth.logging_in}`} onClick={authorize}>
+    <button className={`${auth.login.logging_in}`} onClick={authorize}>
       Login
     </button>
   );


### PR DESCRIPTION
There are a bunch of JS modules with five imports, so I'll split them up into multiple PRs to make them easier to review.

The following modules are converted here:

* `Components/Sidebar/Library`
* `Components/Sidebar/Toggle`
* `Controllers/Theme`
* `Modals/Index`
* `Modals/Modals/SelectMediaFile/Context`
* `Modals/SelectMediaFile/Activators/PlayButton`
* `Pages/Auth/LoginBtn`

The following two modules also had to change due to our use of `React.cloneElement` in `Modals/Index`, which requires a different type for `children` than the one used by `React.PropsWithChildren`:

* `Modals/ConfirmationBox`
* `Modals/InputConfirmationBox`