### PR TITLE
Use null object pattern for React Context objects.

### DIFF
--- a/ui/src/Modals/RematchMedia/Context.js
+++ b/ui/src/Modals/RematchMedia/Context.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const RematchContext = createContext(null);

--- a/ui/src/Modals/RematchMedia/Context.ts
+++ b/ui/src/Modals/RematchMedia/Context.ts
@@ -1,0 +1,61 @@
+import React, { createContext } from "react";
+
+interface ApiEpisode {
+  id: number;
+  name?: string | null;
+  overview?: string | null;
+  episode?: number | null;
+  still?: string | null;
+  still_file?: string | null;
+}
+
+interface ApiSeason {
+  id: number;
+  name?: string | null;
+  poster_path?: string | null;
+  poster_file?: string | null;
+  season_number: number;
+  episodes: ApiEpisode[];
+}
+
+interface ApiMedia {
+  id: number;
+  title: string;
+  release_date?: string | null;
+  overview?: string | null;
+  poster_path?: string | null;
+  backdrop_path?: string | null;
+  poster_file?: string | null;
+  backdrop_file?: string | null;
+  genres: string[];
+  rating?: number | null;
+  seasons: ApiSeason[];
+}
+
+interface RematchContext {
+  mediaType: string;
+  setMediaType: React.Dispatch<React.SetStateAction<string>>;
+  tmdbResults: ApiMedia[];
+  setTmdbResults: React.Dispatch<React.SetStateAction<ApiMedia[]>>;
+  query: string;
+  setQuery: React.Dispatch<React.SetStateAction<string>>;
+  tmdbID: number | null;
+  setTmdbID: React.Dispatch<React.SetStateAction<number | null>>;
+}
+
+// Placeholder to allow an initial RematchContext value to be created.
+const nullFn = () => {};
+
+// Intentionally naming the variable the same as the type.
+// See: https://github.com/typescript-eslint/typescript-eslint/issues/2585
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const RematchContext = createContext<RematchContext>({
+  mediaType: "",
+  setMediaType: nullFn,
+  tmdbResults: [],
+  setTmdbResults: nullFn,
+  query: "",
+  setQuery: nullFn,
+  tmdbID: null,
+  setTmdbID: nullFn,
+});

--- a/ui/src/Modals/SelectMediaFile/Context.ts
+++ b/ui/src/Modals/SelectMediaFile/Context.ts
@@ -1,9 +1,9 @@
-import { createContext } from "react";
+import React, { createContext } from "react";
 
 export interface SelectMediaFileContext {
   open: () => void;
   close: () => void;
-  currentID?: number | null;
+  currentID: number | null;
   setClicked: React.Dispatch<React.SetStateAction<boolean>>;
 }
 

--- a/ui/src/Pages/Library/Context.ts
+++ b/ui/src/Pages/Library/Context.ts
@@ -28,4 +28,13 @@ interface LibraryContext {
 // Intentionally naming the variable the same as the type.
 // See: https://github.com/typescript-eslint/typescript-eslint/issues/2585
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export const LibraryContext = createContext<LibraryContext | null>(null);
+export const LibraryContext = createContext<LibraryContext>({
+  setShowUnmatched: () => {},
+  showUnmatched: false,
+  unmatched: {
+    items: {},
+    fetching: false,
+    fetched: false,
+    error: null,
+  },
+});

--- a/ui/src/Pages/Library/UnmatchedMedia/Context.js
+++ b/ui/src/Pages/Library/UnmatchedMedia/Context.js
@@ -1,3 +1,0 @@
-import { createContext } from "react";
-
-export const SelectUnmatchedContext = createContext(null);

--- a/ui/src/Pages/Library/UnmatchedMedia/Context.ts
+++ b/ui/src/Pages/Library/UnmatchedMedia/Context.ts
@@ -1,0 +1,64 @@
+import React, { createContext } from "react";
+
+interface SelectedFile {
+  id: string;
+  name: string | undefined;
+  parent: string;
+}
+
+interface SelectedFiles {
+  [fileId: string]: SelectedFile;
+}
+
+interface Media {
+  id: number;
+  title: string;
+  poster_path?: string | undefined;
+}
+
+interface SelectUnmatchedContext {
+  selectedFiles: SelectedFiles;
+  setSelectedFiles: React.Dispatch<React.SetStateAction<SelectedFiles>>;
+  currentFolder: string | undefined;
+  setCurrentFolder: React.Dispatch<React.SetStateAction<string | undefined>>;
+  mediaType: string | undefined;
+  setMediaType: React.Dispatch<React.SetStateAction<string | undefined>>;
+  tmdbResults: Media[];
+  setTmdbResults: React.Dispatch<React.SetStateAction<Media[]>>;
+  query: string;
+  setQuery: React.Dispatch<React.SetStateAction<string>>;
+  tmdbID: number | undefined;
+  setTmdbID: React.Dispatch<React.SetStateAction<number | undefined>>;
+  filesMatched: string[];
+  setFilesMatched: React.Dispatch<React.SetStateAction<string[]>>;
+  matching: boolean;
+  setMatching: React.Dispatch<React.SetStateAction<boolean>>;
+  clearData: () => void;
+}
+
+// Placeholder to allow an initial SelectUnmatchedContext value to be created.
+const nullFn = () => {};
+
+// Intentionally naming the variable the same as the type.
+// See: https://github.com/typescript-eslint/typescript-eslint/issues/2585
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SelectUnmatchedContext =
+  createContext<SelectUnmatchedContext | null>({
+    selectedFiles: {},
+    setSelectedFiles: nullFn,
+    currentFolder: undefined,
+    setCurrentFolder: nullFn,
+    mediaType: undefined,
+    setMediaType: nullFn,
+    tmdbResults: [],
+    setTmdbResults: nullFn,
+    query: "",
+    setQuery: nullFn,
+    tmdbID: undefined,
+    setTmdbID: nullFn,
+    filesMatched: [],
+    setFilesMatched: nullFn,
+    matching: false,
+    setMatching: nullFn,
+    clearData: nullFn,
+  });


### PR DESCRIPTION
This converts the remanining "Context" files to TypeScript and uses no-op values for the initial state of contexts, where possible, instead of making their values possibly null. This allows all the components that use these contexts to use them without checking if they're null first, which was annoying boilerplate to cover a case that doesn't really happen in practice.

I tried to determine the type of every property based on how they're currently being used in the code, but there are some inconsistencies where code assumes things are not undefined when they might be, so we might need to adjust some of these definitions as we convert more files to TypeScript and uncover more bugs.