### PR TITLE
Fix Typescript compilation issue

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -53,5 +53,8 @@
     "husky": "^7.0.4",
     "lint-staged": "^12.1.5",
     "prettier": "^2.5.1"
+  },
+  "resolutions": {
+    "**/@types/react": "^17.0.30"
   }
 }


### PR DESCRIPTION
Fixes #428 
The underlying issue was sub-dependencies  pulling in React 18, which would mess up imports.
This fixes it by limiting react in all dependencies to be `^17.0.30` (Which is what is currently used by Dim.

As an aside, if `yarn.lock` was included in the repository, this issue would have been much easier to reproduce. (package-lock.json is included, but I guess Dim used npm in the past).
