### PR TITLE
fix: Component Card/HoverCard.jsx  assign to read only property

### DIFF
--- a/ui/src/Components/Card/HoverCard.jsx
+++ b/ui/src/Components/Card/HoverCard.jsx
@@ -71,7 +71,7 @@ function HoverCard(props) {
     };
 
     if (genres.length > 3) {
-      genres.length = 3;
+      genres.splice(3);
     }
 
     return (


### PR DESCRIPTION
Resolve TypeError: Cannot assign to read only property 'length' of object '[object Array]' error