### PR TITLE
X-Forwarded-User Authentication

### DIFF
--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use time::get_time;
 
+use warp::filters::any::{ any };
 use warp::filters::header::{ header, headers_cloned, optional };
 use warp::http::header::HeaderMap;
 use warp::http::header::AUTHORIZATION;
@@ -94,6 +95,13 @@ pub enum CookieError {
 }
 
 impl warp::reject::Reject for CookieError {}
+
+#[derive(Clone, Debug)]
+pub enum ForwardAuthError {
+    ForwardAuthDisabled
+}
+
+impl warp::reject::Reject for ForwardAuthError {}
 
 impl UserRolesToken {
     /// Method returns whether the token is expired or not.
@@ -254,3 +262,13 @@ pub fn without_token_cookie() -> impl Filter<Extract = ((),), Error = Rejection>
 pub fn with_forwarded_username_header() -> impl Filter<Extract = (String,), Error = Rejection> + Clone {
     header("X-Forwarded-User")
 }
+
+// pub fn with_forward_auth_enabled(enabled: bool) -> impl Filter<Extract = (), Error = Infallible, Rejection> + Clone {
+//     if enabled {
+//         Box::new(any()) as Box<dyn Filter<Extract = (), Error = Rejection> + Clone>
+//     } else {
+//        Box::new(any().and_then(|| async move {
+//             Err(reject::custom(HeaderError::HeaderIsPresent))
+//         })) as Box<dyn Filter<Extract = (), Error = Rejection> + Clone>
+//     }
+// }

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -262,13 +262,3 @@ pub fn without_token_cookie() -> impl Filter<Extract = ((),), Error = Rejection>
 pub fn with_forwarded_username_header() -> impl Filter<Extract = (String,), Error = Rejection> + Clone {
     header("X-Forwarded-User")
 }
-
-// pub fn with_forward_auth_enabled(enabled: bool) -> impl Filter<Extract = (), Error = Infallible, Rejection> + Clone {
-//     if enabled {
-//         Box::new(any()) as Box<dyn Filter<Extract = (), Error = Rejection> + Clone>
-//     } else {
-//        Box::new(any().and_then(|| async move {
-//             Err(reject::custom(HeaderError::HeaderIsPresent))
-//         })) as Box<dyn Filter<Extract = (), Error = Rejection> + Clone>
-//     }
-// }

--- a/dim/src/core.rs
+++ b/dim/src/core.rs
@@ -80,6 +80,7 @@ pub async fn warp_core(
     let api_routes = balanced_or_tree![
         /* NOTE: v1 REST API routes start HERE */
         /* /api/v1/auth and /user routes */
+        auth::filters::headers_login(conn.clone()),
         auth::filters::login(conn.clone()),
         auth::filters::whoami(conn.clone()),
         auth::filters::admin_exists(conn.clone()),

--- a/dim/src/errors.rs
+++ b/dim/src/errors.rs
@@ -47,6 +47,8 @@ pub enum DimError {
     InvalidCredentials,
     #[error(display = "Requested username is not available.")]
     UsernameNotAvailable,
+    #[error(display = "Forward auth is disabled.")]
+    ForwardAuthDisabled,
 }
 
 impl From<sqlx::Error> for DimError {
@@ -71,6 +73,7 @@ impl warp::Reply for DimError {
             Self::Unauthenticated
             | Self::Unauthorized
             | Self::InvalidCredentials
+            | Self::ForwardAuthDisabled
             | Self::NoToken => StatusCode::UNAUTHORIZED,
             Self::UsernameNotAvailable => StatusCode::BAD_REQUEST,
             Self::UnsupportedFile | Self::InvalidMediaType | Self::MissingFieldInBody { .. } => {

--- a/dim/src/errors.rs
+++ b/dim/src/errors.rs
@@ -172,3 +172,23 @@ impl From<std::io::Error> for DimError {
         Self::IOError
     }
 }
+
+
+#[derive(Clone, Debug)]
+pub enum HeadersLoginError {
+    ForwardAuthError(auth::ForwardAuthError),
+    DimError(DimError),
+}
+
+impl warp::reject::Reject for HeadersLoginError {}
+impl<T: Into<DimError>> From<T> for HeadersLoginError {
+    fn from(e: T) -> Self{
+        HeadersLoginError::DimError(e.into())
+    }
+}
+impl From<auth::ForwardAuthError> for HeadersLoginError {
+    fn from(e: auth::ForwardAuthError) -> Self {
+        HeadersLoginError::ForwardAuthError(e)
+    }
+}
+

--- a/dim/src/errors.rs
+++ b/dim/src/errors.rs
@@ -47,8 +47,6 @@ pub enum DimError {
     InvalidCredentials,
     #[error(display = "Requested username is not available.")]
     UsernameNotAvailable,
-    #[error(display = "Forward auth is disabled.")]
-    ForwardAuthDisabled,
 }
 
 impl From<sqlx::Error> for DimError {
@@ -73,7 +71,6 @@ impl warp::Reply for DimError {
             Self::Unauthenticated
             | Self::Unauthorized
             | Self::InvalidCredentials
-            | Self::ForwardAuthDisabled
             | Self::NoToken => StatusCode::UNAUTHORIZED,
             Self::UsernameNotAvailable => StatusCode::BAD_REQUEST,
             Self::UnsupportedFile | Self::InvalidMediaType | Self::MissingFieldInBody { .. } => {

--- a/dim/src/routes/auth.rs
+++ b/dim/src/routes/auth.rs
@@ -311,10 +311,6 @@ pub async fn headers_login(
     conn: DbConnection,
 ) -> Result<impl warp::Reply, HeadersLoginError> {
 
-    // print the username to the console
-    println!("{}", username);
-    println!("{}", get_global_settings().forwarded_user_auth);
-
     if get_global_settings().forwarded_user_auth {
         // TODO: Make this a reader lock then request writer lock iff user needs to be created
         let mut lock = conn.writer().lock_owned().await;

--- a/dim/src/routes/auth.rs
+++ b/dim/src/routes/auth.rs
@@ -260,6 +260,20 @@ pub async fn login(
     Err(errors::DimError::InvalidCredentials)
 }
 
+/// Logs in users with the X-Forwarded-User header
+/// This is used for reverse proxy authentication
+/// 
+/// Sets the token cookie to a valid JWT token
+/// for the user with the username from the X-Forwarded-User
+/// header.
+/// 
+/// If a user with that username doesn't exist,
+/// it will create a new user with that username,
+/// and a random password.
+/// 
+/// # Arguments
+/// * `username` - The username from the X-Forwarded-User header
+/// * `conn` - The database connection
 pub async fn headers_login(
     username: String,
     conn: DbConnection,

--- a/dim/src/routes/auth.rs
+++ b/dim/src/routes/auth.rs
@@ -264,24 +264,6 @@ pub async fn login(
     Err(errors::DimError::InvalidCredentials)
 }
 
-#[derive(Clone, Debug)]
-pub enum HeadersLoginError {
-    ForwardAuthError(auth::ForwardAuthError),
-    DimError(errors::DimError),
-}
-
-impl warp::reject::Reject for HeadersLoginError {}
-impl<T: Into<errors::DimError>> From<T> for HeadersLoginError {
-    fn from(e: T) -> Self{
-        HeadersLoginError::DimError(e.into())
-    }
-}
-impl From<auth::ForwardAuthError> for HeadersLoginError {
-    fn from(e: auth::ForwardAuthError) -> Self {
-        HeadersLoginError::ForwardAuthError(e)
-    }
-}
-
 /// Logs in users with the X-Forwarded-User header
 /// This is used for reverse proxy authentication
 /// 
@@ -299,7 +281,7 @@ impl From<auth::ForwardAuthError> for HeadersLoginError {
 pub async fn headers_login(
     username: String,
     conn: DbConnection,
-) -> Result<impl warp::Reply, HeadersLoginError> {
+) -> Result<impl warp::Reply, errors::HeadersLoginError> {
 
     if get_global_settings().forwarded_user_auth {
         // TODO: Make this a reader lock then request writer lock iff user needs to be created
@@ -347,7 +329,7 @@ pub async fn headers_login(
     }
     else {
         Err(
-            HeadersLoginError::ForwardAuthError(
+            errors::HeadersLoginError::ForwardAuthError(
                 auth::ForwardAuthError::ForwardAuthDisabled
             )
         )

--- a/dim/src/routes/auth.rs
+++ b/dim/src/routes/auth.rs
@@ -53,16 +53,6 @@ pub mod filters {
             })
     }
 
-    // pub fn with_forward_auth_enabled() -> impl Filter<Extract = ((),), Error = Rejection> + Clone {
-    //     any()
-    //         .and_then(|| {
-    //             match get_global_settings().forwarded_user_auth {
-    //                 true => Ok(()),
-    //                 false => Err(reject::custom(ForwardAuthError::ForwardAuthDisabled))
-    //             }
-    //         })
-    // }
-
     pub fn headers_login(
         conn: DbConnection,
     ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {

--- a/dim/src/routes/settings.rs
+++ b/dim/src/routes/settings.rs
@@ -34,6 +34,7 @@ pub struct GlobalSettings {
     pub quiet_boot: bool,
 
     pub disable_auth: bool,
+    pub forwarded_user_auth: bool,
 
     pub verbose: bool,
     pub secret_key: Option<[u8; 16]>,
@@ -59,6 +60,7 @@ impl Default for GlobalSettings {
             metadata_dir: ffpath("config/metadata"),
             quiet_boot: false,
             disable_auth: false,
+            forwarded_user_auth: false,
             verbose: false,
             secret_key: None,
             enable_hwaccel: true,

--- a/ui/src/Pages/Preferences/Advanced/Authentication.jsx
+++ b/ui/src/Pages/Preferences/Advanced/Authentication.jsx
@@ -14,8 +14,16 @@ function Authentication() {
       disableAuth: data.disable_auth,
     };
   });
+  
+  const { forwardAuth } = useSelector((store) => {
+    const { data } = store.settings.globalSettings;
 
-  const handleToggle = useCallback(
+    return {
+      disableAuth: data.forwarded_user_auth,
+    };
+  });
+
+  const handleAuthToggle = useCallback(
     (state) => {
       dispatch(
         updateGlobalSettings({
@@ -26,13 +34,29 @@ function Authentication() {
     [dispatch]
   );
 
+  const handleForwardAuthToggle = useCallback(
+    (state) => {
+      dispatch(
+        updateGlobalSettings({
+          forwarded_user_auth: state,
+        })
+      );
+    },
+    [dispatch]
+  );
+
   return (
     <section>
       <h2>Authentication</h2>
       <Toggle
-        onToggle={handleToggle}
+        onToggle={handleAuthToggle}
         state={!disableAuth}
         name="Require a valid auth token for each request to the server."
+      />
+      <Toggle
+        onToggle={handleForwardAuthToggle}
+        state={forwardAuth}
+        name="Login users with the X-Forwarded-User header.  (Only do this if you're behind a reverse proxy that authenticates users.)"
       />
     </section>
   );


### PR DESCRIPTION
This pull request lets Dim admins delegate authentication to their reverse proxy by automatically logging in clients with the username passed in the `X-Forwarded-User` header.  If no such user exists, one will be created with a strong random password.

Forward authentication is disabled by default, but can be enabled in `config.toml` or in by an admin under `Preferences->Advanced`.

**Requests for review:**
1. Password Generation: Users created in the database as a result of forward authentication are given a random 20 character password which is intended to be unguessable and not intended to be known or used by the person logging in.  Is this sufficiently secure?  Is it the best way to integrate with Dim's authentication system?  Should some alternative method be preferred such as namespacing (salting) all passwords as either plain login or forward auth or refactoring the user model to support password-less users?
2. I created the `HeadersLoginError` enum in [dim/src/errors.rs](dim/src/errors.rs), because I needed an error type which captured `DimError`s and `ForwardAuthError`s, e.g. forward auth is disabled.  I considered enabling/disabling forward auth where it is defined, in [auth/src/lib.rs](auth/src/lib.rs), but I couldn't access the settings module from there.
3. There is some duplication between the user creation code in `register()` and the user creation code in `headers_login()` in [auth/src/lib.rs](auth/src/lib.rs).  Is it worth abstracting out?  If so, where might be a good place?
4. `headers_login()` unconditionally grabs a write lock on the SQLite DB, which it only needs when the username in `X-Forwarded-User` doesn't already exist in the database.  Can I get a read-only lock then conditionally upgrade it to a write lock?