### PR TITLE
Serve Source Maps

### DIFF
--- a/dim/src/routes/statik.rs
+++ b/dim/src/routes/statik.rs
@@ -58,6 +58,7 @@ pub mod filters {
                     let path = PathBuf::from(x.as_str());
                     let mime = match path.extension().and_then(|x| x.to_str()) {
                         Some("js") => "application/javascript",
+                        Some("map") => "application/json",
                         Some("css") => "text/css",
                         Some("woff2") => "font/woff2",
                         Some("png") => "image/png",


### PR DESCRIPTION
Trying to debug the UI in Firefox or Chrome DevTools currently shows minified JS and this error message in the console:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/8960671/168455990-115c48e3-0b47-4f95-ac52-986f956ab804.png">

In place of the source maps, the backend was serving `index.html`.

This pull requests resolves that issue by serving `.map` files along with the compiled `.js` files taking the debugging experience from this:
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/8960671/168456145-a4357419-7cb6-4fde-a0ba-b8eeefb5bb49.png">

to this:
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/8960671/168456163-254b81b5-81ba-41d5-9002-86596346a502.png">
