### PR TITLE
Point libass-wasm dep to @jellyfin/libass-wasm instead of github.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "@types/react-modal": "^3.13.1",
     "dashjs": "=4.1.0",
     "fuse.js": "^6.6.2",
-    "libass-wasm": "https://github.com/jellyfin/JavascriptSubtitlesOctopus",
+    "@jellyfin/libass-wasm": "^4.1.0",
     "node-sass": "^6.0.0",
     "react": "^17.0.2",
     "react-collapse": "^5.1.1",

--- a/ui/src/Pages/VideoPlayer/SsaSubtitles.jsx
+++ b/ui/src/Pages/VideoPlayer/SsaSubtitles.jsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 
 import { VideoPlayerContext } from "./Context";
 
-import SubtitleOctopus from "libass-wasm/dist/js/subtitles-octopus";
+import SubtitleOctopus from "@jellyfin/libass-wasm/dist/js/subtitles-octopus";
 
 import "./Subtitles.scss";
 


### PR DESCRIPTION
Closes: #436