### PR TITLE
feat(tmdb): new tmdb client with request coalescing

### DIFF
--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -24,7 +24,7 @@ nightfall = { git = "https://github.com/Dusk-Labs/nightfall", tag = "0.3.12-rc4"
 database = { path = "../database", default-features = false, optional = true }
 events = { path = "../events" }
 
-serde = { version = "^1.0.125", default-features = false, features = ["derive", "std"] }
+serde = { version = "^1.0.125", default-features = false, features = ["derive", "std", "rc"] }
 serde_derive = "^1.0.125"
 serde_json = "^1.0.64"
 

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "^1.0.64"
 
 lazy_static = "1.4.0"
 walkdir = "2.3.1"
-rand = "0.7.3"
+rand = { version = "0.7.3", features = ["small_rng"] }
 chrono = { version = "0.4.19", features = ["serde"] }
 rust-embed = "^5.9.0"
 torrent-name-parser = "0.6.3"

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -67,6 +67,7 @@ dominant_color = "0.3.0"
 image = "0.24.3"
 parking_lot = "0.12.0"
 dashmap = "5.3.3"
+governor = "0.4.2"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -65,6 +65,8 @@ displaydoc = "0.2.3"
 fuzzy-matcher = "0.3.7"
 dominant_color = "0.3.0"
 image = "0.24.3"
+parking_lot = "0.12.0"
+dashmap = "5.3.3"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -93,7 +93,7 @@ pub struct ExternalActor {
     pub character: String,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MediaType {
     Movie,
     Tv,

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -94,16 +94,16 @@ pub struct ExternalActor {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum MediaType {
+pub enum MediaSearchType {
     Movie,
     Tv,
 }
 
-impl std::fmt::Display for MediaType {
+impl std::fmt::Display for MediaSearchType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            MediaType::Movie => write!(f, "movie"),
-            MediaType::Tv => write!(f, "tv"),
+            MediaSearchType::Movie => write!(f, "movie"),
+            MediaSearchType::Tv => write!(f, "tv"),
         }
     }
 }

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -8,6 +8,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
+pub mod tmdb;
+
 pub type Result<T> = ::core::result::Result<T, Error>;
 
 #[derive(Clone, Display, Debug, Error, Serialize)]
@@ -28,6 +30,13 @@ pub enum Error {
     NoGenreFound { id: u64 },
     /// Other error
     OtherError(#[serde(skip)] Arc<dyn std::error::Error>),
+}
+
+impl Error {
+    pub fn other(error: impl std::error::Error + 'static) -> Self {
+        let err = Arc::new(error);
+        Self::OtherError(err)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd)]
@@ -82,6 +91,21 @@ pub struct ExternalActor {
     pub external_id: String,
     pub name: String,
     pub character: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MediaType {
+    Movie,
+    Tv,
+}
+
+impl std::fmt::Display for MediaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MediaType::Movie => write!(f, "movie"),
+            MediaType::Tv => write!(f, "tv"),
+        }
+    }
 }
 
 /// Trait that must be implemented by external metadata agents which allows the scanners to query

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -18,8 +18,8 @@ pub enum Error {
     Timeout,
     /// Max retry count reached
     ReachedMaxTries,
-    /// The API response could not be deserialized: {0:?}
-    DeserializationError(String),
+    /// The API response could not be deserialized: {error}
+    DeserializationError { body: Arc<str>, error: String },
     /// No results are found: query={query} year={year:?}
     NoResults { query: String, year: Option<i32> },
     /// No seasons found for the id supplied: {id}
@@ -32,6 +32,8 @@ pub enum Error {
     // This error wont be ever serialized and sent over the wire, however it should still be
     // printed in logs somewhere as its very unexpected.
     OtherError(#[serde(skip)] Arc<dyn std::error::Error>),
+    /// The remote API returned an error ({code}): {message}
+    RemoteApiError { code: u16, message: String },
 }
 
 impl Error {

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -28,7 +28,9 @@ pub enum Error {
     NoEpisodesFound { id: u64, season: u64 },
     /// Could not find genre with supplied id: {id}
     NoGenreFound { id: u64 },
-    /// Other error
+    /// Other error, usually contains an error that shouldn't happen unless theres a bug.
+    // This error wont be ever serialized and sent over the wire, however it should still be
+    // printed in logs somewhere as its very unexpected.
     OtherError(#[serde(skip)] Arc<dyn std::error::Error>),
 }
 

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -133,5 +133,19 @@ pub trait ExternalQueryShow: ExternalQuery {
     /// Get all seasons for an external id. Seasons must be ranked in order by their number.
     async fn seasons_for_id(&self, external_id: &str) -> Result<Vec<ExternalSeason>>;
     /// Get all episodes for a season ranked in order of the episode number.
-    async fn episodes_for_season(&self, season_id: &str) -> Result<Vec<ExternalEpisode>>;
+    // FIXME: TMDB doesnt support fetching by season id, but rather by season number and tv show
+    // id. However other backends could have the opposite situation
+    // As such its ideal that we have all external ids follow a standard scheme, for instance a
+    // tmdb movie id would look like this `tmdb://12345`, an imdb media id would be similar
+    // `imdb://tt1234556`. Season ids would also track their parent media id, so a season id would
+    // be like this `tmdb://12345?season_id=32&season=2`, similarly episodes would also track their
+    // parent ids, including season id, number, tv show id, episode number and episode id. This is
+    // not ideal but it should cover all of the cases.
+    //
+    // For now this API accepts a external id and season number but this is subject to change.
+    async fn episodes_for_season(
+        &self,
+        external_id: &str,
+        season_number: u64,
+    ) -> Result<Vec<ExternalEpisode>>;
 }

--- a/dim/src/external/mod.rs
+++ b/dim/src/external/mod.rs
@@ -94,6 +94,7 @@ pub struct ExternalEpisode {
 pub struct ExternalActor {
     pub external_id: String,
     pub name: String,
+    pub profile_path: Option<String>,
     pub character: String,
 }
 
@@ -122,8 +123,8 @@ pub trait ExternalQuery {
     /// Search by external id. This must return a singular `ExternalMedia` which has the id passed
     /// in.
     async fn search_by_id(&self, external_id: &str) -> Result<ExternalMedia>;
-    /// Get all actors for an external id. Actors must be ordered in order of importance.
-    async fn actors(&self, external_id: &str) -> Result<Vec<ExternalActor>>;
+    /// Get all actors for a media by external id. Actors must be ordered in order of importance.
+    async fn cast(&self, external_id: &str) -> Result<Vec<ExternalActor>>;
 }
 
 /// Trait must be implemented by all external metadata agents which support querying for tv shows.

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -6,8 +6,6 @@ use crate::external::MediaSearchType;
 
 /// The type of our hashmap we use for caching.
 ///
-/// The current implementation is using [flurry](https://docs.rs/flurry)
-///
 pub(super) type CacheMap = Arc<dashmap::DashMap<CacheKey, Option<CacheValue>>>;
 
 /// The key type used within the [CacheMap], refers to [CacheValue]s.

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -16,6 +16,8 @@ pub(super) enum CacheKey {
     Search { title: String, year: Option<i32> },
     /// Genre List
     GenreList { media_type: MediaSearchType },
+    /// Searching by ID
+    ById { id: String, ty: MediaSearchType },
 }
 
 pub(super) type PendingRequestTx =

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use crate::external::MediaSearchType;
+
+/// The type of our hashmap we use for caching.
+///
+/// The current implementation is using [flurry](https://docs.rs/flurry)
+///
+pub(super) type CacheMap = Arc<dashmap::DashMap<CacheKey, Option<CacheValue>>>;
+
+/// The key type used within the [CacheMap], refers to [CacheValue]s.
+///
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) enum CacheKey {
+    /// A search result
+    Search { title: String, year: Option<i32> },
+    /// Genre List
+    GenreList { media_type: MediaSearchType },
+}
+
+pub(super) type PendingRequestTx =
+    broadcast::Sender<Result<Arc<str>, super::TMDBClientRequestError>>;
+
+/// The value type used within the [CacheMap], refered to by [CacheKey]s.
+#[derive(Clone)]
+
+pub(super) enum CacheValue {
+    /// The request responsible for fulfilling this data is currently in flight.
+    RequestInFlight { tx: PendingRequestTx },
+    /// The responses body as UTF-8, cached.
+    Body { text: Arc<str> },
+}
+
+impl CacheValue {
+    /// get the data out of the value, if it is still pending, wait for it and turn errors into None.
+    pub(super) async fn data(&self) -> Option<Arc<str>> {
+        match self {
+            CacheValue::RequestInFlight { tx } => {
+                tx.subscribe().recv().await.map(|o| o.ok()).ok().flatten()
+            }
+            CacheValue::Body { text } => Some(Arc::clone(text)),
+        }
+    }
+}

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -47,4 +47,13 @@ impl CacheValue {
             CacheValue::Body { text, .. } => Ok(Arc::clone(text)),
         }
     }
+
+    pub fn mem_size(&self) -> usize {
+        let body_size = match self {
+            Self::Body { text, .. } => text.as_bytes().len(),
+            _ => 0,
+        };
+
+        core::mem::size_of::<CacheValue>() + body_size
+    }
 }

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -26,8 +26,12 @@ pub(super) type PendingRequestTx =
 pub(super) enum CacheValue {
     /// The request responsible for fulfilling this data is currently in flight.
     RequestInFlight { tx: PendingRequestTx },
-    /// The responses body as UTF-8, cached.
-    Body { text: Arc<str> },
+    /// The responses body as UTF-8, cached. This also has a TTL. Once the TTL is reached, the
+    /// value should be ignored/discarded.
+    Body {
+        text: Arc<str>,
+        ttl: std::time::Instant,
+    },
 }
 
 impl CacheValue {
@@ -39,7 +43,8 @@ impl CacheValue {
                 .recv()
                 .await
                 .map_err(super::TMDBClientRequestError::RecvError)?,
-            CacheValue::Body { text } => Ok(Arc::clone(text)),
+
+            CacheValue::Body { text, .. } => Ok(Arc::clone(text)),
         }
     }
 }

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -1,7 +1,21 @@
 use crate::external::MediaSearchType;
 
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
 use tokio::sync::broadcast;
+use tokio::task::spawn_blocking;
+use tokio::task::JoinHandle;
+
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+// How long we should sleep in-between cache evictions. Defaults to 15 seconds.
+const EVICT_EVERY: Duration = Duration::from_millis(15_000);
 
 /// The type of our hashmap we use for caching.
 pub(super) type CacheMap = Arc<dashmap::DashMap<CacheKey, Option<CacheValue>>>;
@@ -22,16 +36,12 @@ pub(super) type PendingRequestTx =
 
 /// The value type used within the [CacheMap], refered to by [CacheKey]s.
 #[derive(Clone)]
-
 pub(super) enum CacheValue {
     /// The request responsible for fulfilling this data is currently in flight.
     RequestInFlight { tx: PendingRequestTx },
     /// The responses body as UTF-8, cached. This also has a TTL. Once the TTL is reached, the
     /// value should be ignored/discarded.
-    Body {
-        text: Arc<str>,
-        ttl: std::time::Instant,
-    },
+    Body { text: Arc<str>, ttl: Instant },
 }
 
 impl CacheValue {
@@ -55,5 +65,132 @@ impl CacheValue {
         };
 
         core::mem::size_of::<CacheValue>() + body_size
+    }
+}
+
+/// Simple worker which handles cache eviction. It doesn't promise that our memory usage will
+/// always be below our max target, but it does promise eventual consistency.
+///
+/// The policy is that expelling TTL'd items should be handled lazily, however it will randomly
+/// evict items when our usage reaches our max.
+pub(super) struct CacheEviction {
+    cache: CacheMap,
+    usage: Arc<AtomicUsize>,
+    max_usage: usize,
+}
+
+impl CacheEviction {
+    pub(super) fn new(cache: CacheMap, usage: Arc<AtomicUsize>, max_usage: usize) -> Self {
+        Self {
+            cache,
+            usage,
+            max_usage,
+        }
+    }
+
+    pub(super) fn start_policy(self) -> AbortOnDropHandle {
+        let (stop_tx, mut rx) = broadcast::channel(1);
+
+        let handle = spawn_blocking(move || {
+            while matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty)) {
+                let now = Instant::now();
+                let items = self.evict();
+                let duration = now.elapsed().as_millis();
+
+                tracing::info!(
+                    items = items,
+                    duration_ms = duration,
+                    "tmdb cache eviction finished."
+                );
+                thread::sleep(EVICT_EVERY);
+            }
+        });
+
+        AbortOnDropHandle { handle, stop_tx }
+    }
+
+    fn evict(&self) -> usize {
+        if self.usage.fetch_min(self.max_usage, Ordering::Relaxed) < self.max_usage {
+            return 0;
+        }
+
+        // This is probably gonna be very slow as our cache grows.
+        // we want to evict 5% of our items.
+        // FIXME: Absolutely not ideal
+        let cache_len = self.cache.len();
+        let to_delete = cache_len / 20;
+
+        let mut rng = SmallRng::from_entropy();
+
+        self.cache.retain(|_, v| {
+            let size = if let Some(ref v) = v {
+                v.mem_size()
+            } else {
+                return true;
+            };
+
+            if size == 0 {
+                return true;
+            }
+
+            if rng.gen_range(0, cache_len) < to_delete {
+                self.usage.fetch_sub(size, Ordering::Relaxed);
+                return false;
+            }
+
+            true
+        });
+
+        let new_cache_len = self.cache.len();
+
+        cache_len - new_cache_len
+    }
+}
+
+pub struct AbortOnDropHandle {
+    handle: JoinHandle<()>,
+    stop_tx: broadcast::Sender<()>,
+}
+
+impl Drop for AbortOnDropHandle {
+    fn drop(&mut self) {
+        let _ = self.stop_tx.send(());
+        self.handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_eviction() {
+        let cache = CacheMap::default();
+        // pretend we already have 100 items in the cache.
+        let mut usage = 0;
+
+        for i in 0..=100 {
+            let value = CacheValue::Body {
+                text: format!("{i}").into(),
+                ttl: Instant::now(),
+            };
+
+            usage += value.mem_size();
+
+            cache.insert(
+                CacheKey::Search {
+                    title: format!("{i}").into(),
+                    year: None,
+                },
+                Some(value),
+            );
+        }
+
+        let usage = Arc::new(AtomicUsize::new(usage));
+        let policy = CacheEviction::new(cache.clone(), usage.clone(), 0);
+        let evicted = policy.evict();
+
+        assert!(evicted < 100);
+        assert!(evicted > 0);
     }
 }

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -29,6 +29,8 @@ pub(super) enum CacheKey {
     GenreList { media_type: MediaSearchType },
     /// Searching by ID
     ById { id: String, ty: MediaSearchType },
+    /// Search for an actor by id
+    ActorById { id: String },
 }
 
 pub(super) type PendingRequestTx =

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -31,6 +31,8 @@ pub(super) enum CacheKey {
     ById { id: String, ty: MediaSearchType },
     /// Search for an actor by id
     ActorById { id: String },
+    /// Get all episodes for a season
+    Episodes { id: String, season_number: u64 },
 }
 
 pub(super) type PendingRequestTx =

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -102,6 +102,7 @@ impl CacheEviction {
                     duration_ms = duration,
                     "tmdb cache eviction finished."
                 );
+
                 thread::sleep(EVICT_EVERY);
             }
         });
@@ -169,7 +170,7 @@ mod tests {
         // pretend we already have 100 items in the cache.
         let mut usage = 0;
 
-        for i in 0..=100 {
+        for i in 0..=10000 {
             let value = CacheValue::Body {
                 text: format!("{i}").into(),
                 ttl: Instant::now(),
@@ -190,7 +191,7 @@ mod tests {
         let policy = CacheEviction::new(cache.clone(), usage.clone(), 0);
         let evicted = policy.evict();
 
-        assert!(evicted < 100);
+        assert!(evicted < 10000);
         assert!(evicted > 0);
     }
 }

--- a/dim/src/external/tmdb/metadata_provider.rs
+++ b/dim/src/external/tmdb/metadata_provider.rs
@@ -1,0 +1,298 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+
+use tokio::sync::broadcast;
+
+use crate::external::{Result as QueryResult, *};
+use core::result::Result;
+
+use super::cache_control::{CacheKey, CacheMap, CacheValue};
+use super::raw_client::TMDBClient;
+use super::*;
+
+/// TMDB Metadata Provider implements `ExternalQuery` and handles request coalescing and caching locally.
+pub struct TMDBMetadataProvider {
+    pub(super) api_key: Arc<str>,
+    pub(super) http_client: reqwest::Client,
+    cache: CacheMap,
+}
+
+impl Clone for TMDBMetadataProvider {
+    fn clone(&self) -> Self {
+        Self {
+            api_key: self.api_key.clone(),
+            http_client: self.http_client.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+impl TMDBMetadataProvider {
+    pub fn new(api_key: &str) -> Self {
+        let http_client = reqwest::ClientBuilder::new()
+            .user_agent(APP_USER_AGENT)
+            .build()
+            .expect("building this client should never fail.");
+
+        let api_key: Arc<str> = api_key.to_owned().into_boxed_str().into();
+
+        Self {
+            api_key,
+            http_client,
+            cache: Default::default(),
+        }
+    }
+
+    /// curry this metadata provider to supply search results for TV shows.
+    #[inline(always)]
+    pub fn tv_shows(&self) -> MetadataProviderOf<TvShows> {
+        MetadataProviderOf {
+            provider: self.clone(),
+            _key: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub fn movies(&self) -> MetadataProviderOf<Movies> {
+        MetadataProviderOf {
+            provider: self.clone(),
+            _key: PhantomData,
+        }
+    }
+
+    /// insert a default [CacheValue] if the slot at a given key is not present.
+    fn insert_value_if_empty(&self, key: &CacheKey) -> (CacheValue, bool) {
+        // grab the entry or instert RwLock::new(None) if not present.
+        let mut entry = self.cache.entry(key.clone()).or_default();
+
+        // fast path: cache hits, no writers and the value is present.
+        {
+            let read_guard = entry.value();
+            if let Some(value) = read_guard.as_ref() {
+                return (value.clone(), false);
+            }
+        }
+
+        // slow path: get a write guard, if the slot is still uninit when we acquire; initialize it.s
+        let slot = entry.value_mut();
+
+        match slot.as_ref() {
+            // someone initialized the slot before we got the write guard, use their value.
+            Some(value) => (value.clone(), false),
+            // we're still first, initialize the value and keep going.
+            None => {
+                let (tx, _) = broadcast::channel(1);
+                let value = CacheValue::RequestInFlight { tx };
+                slot.replace(value.clone());
+                (value, true)
+            }
+        }
+    }
+
+    /// perform request coalescing; when two futures are made with the same key the duplicates wait for the original to broadcast the results.
+    async fn coalesce_request<F, Fut>(
+        &self,
+        key: &CacheKey,
+        make_request_future: F,
+    ) -> Result<Arc<str>, Error>
+    where
+        F: FnOnce(TMDBClient) -> Fut,
+        Fut: Future<Output = Result<Arc<str>, TMDBClientRequestError>> + Send + 'static,
+    {
+        let (value, we_own_future) = { self.insert_value_if_empty(key) };
+
+        match (we_own_future, value) {
+            // only if we own the future that was spawned should we upate the
+            // value once we get the response.
+            (true, CacheValue::RequestInFlight { tx }) => {
+                let client = TMDBClient {
+                    provider: self.clone(),
+                };
+
+                let tx_ = tx.clone();
+                let fut = make_request_future(client);
+                tokio::spawn(async move {
+                    let output = fut.await;
+                    let _ = tx_.send(output);
+                });
+
+                match { CacheValue::RequestInFlight { tx } }.data().await {
+                    Some(text) => {
+                        let body = Arc::clone(&text);
+
+                        let _ = match self.cache.get_mut(key) {
+                            Some(mut entry_ref) => entry_ref.replace(CacheValue::Body { text }),
+                            None => unreachable!("slot was None when original task got its result"),
+                        };
+
+                        Ok(body)
+                    }
+                    // if an error was yeeted back during the request then purge the cache entry.
+                    None => {
+                        // clear the cache for values that could not be populated.
+                        let _ = self.cache.remove(&key);
+                        Err(Error::Timeout)
+                    }
+                }
+            }
+
+            (_, value) => value.data().await.ok_or(Error::Timeout),
+        }
+    }
+
+    async fn search(
+        &self,
+        title: &str,
+        year: Option<i32>,
+        media_type: MediaSearchType,
+    ) -> QueryResult<Vec<ExternalMedia>> {
+        let title = title.to_string();
+        let key = CacheKey::Search {
+            title: title.clone(),
+            year,
+        };
+
+        let st = self
+            .coalesce_request(&key, |client| async move {
+                client
+                    .search(media_type, &title, year)
+                    .await
+                    .map(|st| st.into_boxed_str().into())
+            })
+            .await?;
+
+        let mut search = serde_json::from_str::<SearchResponse>(&st).map_err(Error::other)?;
+
+        // fill in the genre names for the search results.
+        {
+            let key = CacheKey::GenreList { media_type };
+            let st = self
+                .coalesce_request(&key, |client| async move {
+                    client
+                        .genre_list(media_type)
+                        .await
+                        .map(|st| st.into_boxed_str().into())
+                })
+                .await?;
+
+            let genre_list = serde_json::from_str::<GenreList>(&st).map_err(Error::other)?;
+
+            let mut genre_id_cache = HashMap::<u64, Genre>::with_capacity(search.results.len());
+            for media in search.results.iter_mut() {
+                if let Some(TMDBMediaObject {
+                    genre_ids: Some(ids),
+                    genres,
+                    ..
+                }) = media
+                {
+                    for genre_id in ids.clone() {
+                        if let Some(genre) = genre_id_cache.get(&genre_id) {
+                            genres.push(genre.name.clone());
+                        } else if let Some(genre) =
+                            genre_list.genres.iter().find(|x| x.id == genre_id)
+                        {
+                            genre_id_cache.insert(genre_id, genre.clone());
+                            genres.push(genre.name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        let media = search
+            .results
+            .into_iter()
+            .flatten()
+            .map(|media| ExternalMedia {
+                external_id: media.id.to_string(),
+                title: media.title,
+                description: media.overview,
+                release_date: media
+                    .release_date
+                    .and_then(|date| chrono::DateTime::from_str(&date).ok()),
+                posters: media.poster_path.into_iter().collect(),
+                backdrops: media.backdrop_path.into_iter().collect(),
+                genres: media.genres,
+                rating: media.vote_average,
+                duration: media.runtime.map(|n| Duration::from_secs(n)),
+            })
+            .collect::<Vec<_>>();
+
+        Ok(media)
+    }
+
+    async fn search_by_id(&self, external_id: &str) -> QueryResult<ExternalMedia> {
+        todo!()
+    }
+
+    async fn actors(&self, external_id: &str) -> QueryResult<Vec<ExternalActor>> {
+        todo!()
+    }
+}
+
+// -- TMDBMetadataProviderRef<T>
+
+/// Used to key [TMDBMetadataProviderRef] to search for TV shows, compliments [Movies].
+pub struct TvShows;
+
+/// Used to key [TMDBMetadataProviderRef] to search for movies, compliments [TvShows].
+pub struct Movies;
+
+/// An instance of [TMDBMetadataProvider] with a generic parameter to infer the [MediaType] for searches.
+pub struct MetadataProviderOf<K>
+where
+    K: Send + Sync + 'static,
+{
+    pub provider: TMDBMetadataProvider,
+    _key: PhantomData<K>,
+}
+
+mod sealed {
+    use super::{MediaSearchType, Movies, TvShows};
+
+    /// Used to associate a constant [MediaType] with another type.
+    pub trait AssocMediaTypeConst {
+        const MEDIA_TYPE: MediaSearchType;
+    }
+
+    impl AssocMediaTypeConst for TvShows {
+        const MEDIA_TYPE: MediaSearchType = MediaSearchType::Tv;
+    }
+
+    impl AssocMediaTypeConst for Movies {
+        const MEDIA_TYPE: MediaSearchType = MediaSearchType::Movie;
+    }
+}
+
+#[async_trait]
+impl<K> ExternalQuery for MetadataProviderOf<K>
+where
+    K: sealed::AssocMediaTypeConst + Send + Sync + 'static,
+{
+    async fn search(&self, title: &str, year: Option<i32>) -> QueryResult<Vec<ExternalMedia>> {
+        self.provider.search(title, year, K::MEDIA_TYPE).await
+    }
+
+    async fn search_by_id(&self, external_id: &str) -> QueryResult<ExternalMedia> {
+        todo!()
+    }
+
+    async fn actors(&self, external_id: &str) -> QueryResult<Vec<ExternalActor>> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl ExternalQueryShow for MetadataProviderOf<TvShows> {
+    async fn seasons_for_id(&self, external_id: &str) -> QueryResult<Vec<ExternalSeason>> {
+        todo!()
+    }
+
+    async fn episodes_for_season(&self, season_id: &str) -> QueryResult<Vec<ExternalEpisode>> {
+        todo!()
+    }
+}

--- a/dim/src/external/tmdb/mod.rs
+++ b/dim/src/external/tmdb/mod.rs
@@ -1,19 +1,7 @@
-// #![deny(warnings)]
+//! A TMDB client implementation with request coalescing and client-side rate-limiting.
+//!
 
-use std::collections::HashMap;
-use std::future::Future;
-use std::marker::PhantomData;
-
-use async_trait::async_trait;
-
-use displaydoc::Display;
-
-use tokio::sync::broadcast;
-
-use parking_lot::RwLock;
-
-use super::{Result as QueryResult, *};
-use core::result::Result;
+use std::sync::Arc;
 
 /// The User-Agent is generated from the package name "dim" and the version so "dim/0.x.y.z"
 pub const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -21,45 +9,15 @@ pub const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARG
 /// The base url used to access TMDB;
 pub const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";
 
-// -- TMDB API Data Models
+mod cache_control;
+mod metadata_provider;
+mod raw_client;
 
-#[derive(Deserialize, Clone, Debug)]
-struct SearchResponse {
-    results: Vec<Option<TMDBMediaObject>>,
-}
+pub use metadata_provider::{MetadataProviderOf, Movies, TMDBMetadataProvider, TvShows};
+use raw_client::{Genre, GenreList, SearchResponse, TMDBMediaObject};
 
-#[derive(Deserialize, Clone, Debug)]
-struct TMDBMediaObject {
-    id: u64,
-    #[serde(rename(deserialize = "title", deserialize = "name"))]
-    title: String,
-    #[serde(rename(deserialize = "release_date", deserialize = "first_air_date"))]
-    release_date: Option<String>,
-    overview: Option<String>,
-    vote_average: Option<f64>,
-    poster_path: Option<String>,
-    backdrop_path: Option<String>,
-    genre_ids: Option<Vec<u64>>,
-    #[serde(skip_deserializing)]
-    genres: Vec<String>,
-    runtime: Option<u64>,
-}
-
-#[derive(Deserialize)]
-struct GenreList {
-    genres: Vec<Genre>,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct Genre {
-    id: u64,
-    name: String,
-}
-
-// -- TMDBClient
-
-#[derive(Debug, Display, Clone, thiserror::Error)]
-enum TMDBClientRequestError {
+#[derive(Debug, displaydoc::Display, Clone, thiserror::Error)]
+pub(self) enum TMDBClientRequestError {
     /// The body of a response was not value UTF-8.
     InvalidUTF8Body,
     /// the error comes from reqwest.
@@ -72,404 +30,33 @@ impl TMDBClientRequestError {
     }
 }
 
-/// Internal TMDB client type used for building and making requests.
-struct TMDBClient {
-    provider: TMDBMetadataProvider,
-}
-
-impl TMDBClient {
-    fn make_request<A, T>(
-        &self,
-        args: A,
-        path: String,
-    ) -> impl Future<Output = Result<String, TMDBClientRequestError>>
-    where
-        A: IntoIterator<Item = (T, T)>,
-        T: ToString,
-    {
-        let url = format!("{TMDB_BASE_URL}{path}");
-        let args: Vec<_> = args
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-
-        let request = self.provider.http_client.get(url).query(&args);
-
-        async move {
-            let response = request
-                .send()
-                .await
-                .map_err(TMDBClientRequestError::reqwest)?;
-
-            let body = response
-                .bytes()
-                .await
-                .map_err(TMDBClientRequestError::reqwest)?;
-
-            std::str::from_utf8(&body)
-                .map_err(|_| TMDBClientRequestError::InvalidUTF8Body)
-                .map(|st| st.to_string())
-        }
-    }
-
-    async fn genre_list(&self, media_type: MediaType) -> Result<String, TMDBClientRequestError> {
-        self.make_request(
-            vec![("api_key", self.provider.api_key.as_ref())],
-            format!("/genre/{media_type}/list"),
-        )
-        .await
-    }
-
-    async fn search(
-        &self,
-        media_type: MediaType,
-        title: &str,
-        year: Option<i32>,
-    ) -> Result<String, TMDBClientRequestError> {
-        let mut args = vec![
-            ("api_key", self.provider.api_key.as_ref()),
-            ("language", "en-US"),
-            ("query", title),
-            ("page", "1"),
-            ("include_adult", "false"),
-        ]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v.to_string()))
-        .chain(
-            year.into_iter()
-                .map(|n| ("year".to_string(), n.to_string())),
-        );
-
-        self.make_request(args, format!("/search/{media_type}"))
-            .await
-    }
-}
-
-// -- cache control
-
-/// The type of our hashmap we use for caching.
-///
-/// The current implementation is using [flurry](https://docs.rs/flurry)
-///
-type CacheMap = Arc<dashmap::DashMap<CacheKey, RwLock<Option<CacheValue>>>>;
-
-/// The key type used within the [CacheMap], refers to [CacheValue]s.
-///
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum CacheKey {
-    /// A search result
-    Search { title: String, year: Option<i32> },
-    /// Genre List
-    GenreList { media_type: MediaType },
-}
-
-type PendingRequestTx = broadcast::Sender<Result<Arc<str>, TMDBClientRequestError>>;
-
-/// The value type used within the [CacheMap], refered to by [CacheKey]s.
-#[derive(Clone)]
-enum CacheValue {
-    /// The request responsible for fulfilling this data is currently in flight.
-    RequestInFlight { tx: PendingRequestTx },
-    /// The responses body as UTF-8, cached.
-    Body { text: Arc<str> },
-}
-
-impl CacheValue {
-    /// get the data out of the value, if it is still pending, wait for it and turn errors into None.
-    async fn data(&self) -> Option<Arc<str>> {
-        match self {
-            CacheValue::RequestInFlight { tx } => {
-                tx.subscribe().recv().await.map(|o| o.ok()).ok().flatten()
-            }
-            CacheValue::Body { text } => Some(Arc::clone(text)),
-        }
-    }
-}
-
-// -- TMDBMetadataProvider
-
-/// TMDB Metadata Provider implements `ExternalQuery` and handles request coalescing and caching locally.
-pub struct TMDBMetadataProvider {
-    api_key: Arc<str>,
-    http_client: reqwest::Client,
-    cache: CacheMap,
-}
-
-impl Clone for TMDBMetadataProvider {
-    fn clone(&self) -> Self {
-        Self {
-            api_key: self.api_key.clone(),
-            http_client: self.http_client.clone(),
-            cache: self.cache.clone(),
-        }
-    }
-}
-
-impl TMDBMetadataProvider {
-    pub fn new(api_key: String) -> Self {
-        let http_client = reqwest::ClientBuilder::new()
-            .user_agent(APP_USER_AGENT)
-            .build()
-            .expect("building this client should never fail.");
-
-        let api_key: Arc<str> = api_key.into_boxed_str().into();
-
-        Self {
-            api_key,
-            http_client,
-            cache: Default::default(),
-        }
-    }
-
-    /// insert a default [CacheValue] if the slot at a given key is not present.
-    fn insert_value_if_empty(&self, key: &CacheKey) -> (CacheValue, bool) {
-        // grab the entry or instert RwLock::new(None) if not present.
-        let entry = self.cache.entry(key.clone()).or_default();
-
-        // fast path: cache hits, no writers and the value is present.
-        {
-            let read_guard = entry.value().read();
-            if let Some(value) = read_guard.as_ref() {
-                return (value.clone(), false);
-            }
-        }
-
-        // slow path: get a write guard, if the slot is still uninit when we acquire; initialize it.s
-        let mut slot = entry.value().write();
-
-        match slot.as_ref() {
-            // someone initialized the slot before we got the write guard, use their value.
-            Some(value) => (value.clone(), false),
-            // we're still first, initialize the value and keep going.
-            None => {
-                let (tx, _) = broadcast::channel(1);
-                let value = CacheValue::RequestInFlight { tx };
-                slot.replace(value.clone());
-                (value, true)
-            }
-        }
-    }
-
-    /// perform request coalescing; when two futures are made with the same key the duplicates wait for the original to broadcast the results.
-    async fn coalesce_request<F, Fut>(
-        &self,
-        key: &CacheKey,
-        make_request_future: F,
-    ) -> Result<Arc<str>, Error>
-    where
-        F: FnOnce(TMDBClient) -> Fut,
-        Fut: Future<Output = Result<Arc<str>, TMDBClientRequestError>> + Send + 'static,
-    {
-        let (value, we_own_future) = { self.insert_value_if_empty(key) };
-
-        match (we_own_future, value) {
-            // only if we own the future that was spawned should we upate the
-            // value once we get the response.
-            (true, CacheValue::RequestInFlight { tx }) => {
-                let client = TMDBClient {
-                    provider: self.clone(),
-                };
-
-                let tx_ = tx.clone();
-                let fut = make_request_future(client);
-                tokio::spawn(async move {
-                    let output = fut.await;
-                    let _ = tx_.send(output);
-                });
-
-                match { CacheValue::RequestInFlight { tx } }.data().await {
-                    Some(text) => {
-                        let body = Arc::clone(&text);
-
-                        let _ = match self.cache.get(key) {
-                            Some(rw_lock) => rw_lock.write().replace(CacheValue::Body { text }),
-                            None => unreachable!("slot was None when original task got its result"),
-                        };
-
-                        Ok(body)
-                    }
-                    // if an error was yeeted back during the request then purge the cache entry.
-                    None => {
-                        // clear the cache for values that could not be populated.
-                        let _ = self.cache.remove(&key);
-                        Err(Error::Timeout)
-                    }
-                }
-            }
-
-            (_, value) => value.data().await.ok_or(Error::Timeout),
-        }
-    }
-
-    async fn search(
-        &self,
-        title: &str,
-        year: Option<i32>,
-        media_type: MediaType,
-    ) -> QueryResult<Vec<ExternalMedia>> {
-        let title = title.to_string();
-        let key = CacheKey::Search {
-            title: title.clone(),
-            year,
-        };
-
-        let st = self
-            .coalesce_request(&key, |client| async move {
-                client
-                    .search(media_type, &title, year)
-                    .await
-                    .map(|st| st.into_boxed_str().into())
-            })
-            .await?;
-
-        let mut search = serde_json::from_str::<SearchResponse>(&st).map_err(Error::other)?;
-
-        // fill in the genre names for the search results.
-        {
-            let key = CacheKey::GenreList { media_type };
-            let st = self
-                .coalesce_request(&key, |client| async move {
-                    client
-                        .genre_list(media_type)
-                        .await
-                        .map(|st| st.into_boxed_str().into())
-                })
-                .await?;
-
-            let genre_list = serde_json::from_str::<GenreList>(&st).map_err(Error::other)?;
-
-            let mut genre_id_cache = HashMap::<u64, Genre>::with_capacity(search.results.len());
-            for media in search.results.iter_mut() {
-                if let Some(TMDBMediaObject {
-                    genre_ids: Some(ids),
-                    genres,
-                    ..
-                }) = media
-                {
-                    for genre_id in ids.clone() {
-                        if let Some(genre) = genre_id_cache.get(&genre_id) {
-                            genres.push(genre.name.clone());
-                        } else if let Some(genre) =
-                            genre_list.genres.iter().find(|x| x.id == genre_id)
-                        {
-                            genre_id_cache.insert(genre_id, genre.clone());
-                            genres.push(genre.name.clone());
-                        }
-                    }
-                }
-            }
-        }
-
-        let media = search
-            .results
-            .into_iter()
-            .flatten()
-            .map(|media| ExternalMedia {
-                external_id: media.id.to_string(),
-                title: media.title,
-                description: media.description,
-                release_date: media.release_date,
-                posters: media.poster_path,
-                backdrops: media.backdrop_path,
-                genres: media.genres,
-                rating: media.vote_average,
-                duration: media.runtime,
-            })
-            .collect::<Vec<_>>();
-
-        Ok(media)
-    }
-
-    async fn search_by_id(&self, external_id: &str) -> QueryResult<ExternalMedia> {
-        todo!()
-    }
-
-    async fn actors(&self, external_id: &str) -> QueryResult<Vec<ExternalActor>> {
-        todo!()
-    }
-}
-
-// -- TMDBMetadataProviderRef<T>
-
-/// Used to key [TMDBMetadataProviderRef] to search for TV shows, compliments [Movies].
-pub struct TvShows;
-
-/// Used to key [TMDBMetadataProviderRef] to search for movies, compliments [TvShows].
-pub struct Movies;
-
-/// An instance of [TMDBMetadataProvider] with a generic parameter to infer the [MediaType] for searches.
-pub struct TMDBMetadataProviderRef<K>
-where
-    K: Send + Sync + 'static,
-{
-    pub provider: TMDBMetadataProvider,
-    _key: PhantomData<K>,
-}
-
-mod sealed {
-    use super::{MediaType, Movies, TvShows};
-
-    /// Used to associate a constant [MediaType] with another type.
-    pub trait AssocMediaTypeConst {
-        const MEDIA_TYPE: MediaType;
-    }
-
-    impl AssocMediaTypeConst for TvShows {
-        const MEDIA_TYPE: MediaType = MediaType::Tv;
-    }
-
-    impl AssocMediaTypeConst for Movies {
-        const MEDIA_TYPE: MediaType = MediaType::Tv;
-    }
-}
-
-#[async_trait]
-impl<K> ExternalQuery for TMDBMetadataProviderRef<K>
-where
-    K: sealed::AssocMediaTypeConst + Send + Sync + 'static,
-{
-    async fn search(&self, title: &str, year: Option<i32>) -> QueryResult<Vec<ExternalMedia>> {
-        self.provider.search(title, year, K::MEDIA_TYPE).await
-    }
-
-    async fn search_by_id(&self, external_id: &str) -> QueryResult<ExternalMedia> {
-        todo!()
-    }
-
-    async fn actors(&self, external_id: &str) -> QueryResult<Vec<ExternalActor>> {
-        todo!()
-    }
-}
-
-#[async_trait]
-impl<K> ExternalQueryShow for TMDBMetadataProviderRef<K>
-where
-    K: sealed::AssocMediaTypeConst + Send + Sync + 'static,
-{
-    async fn seasons_for_id(&self, external_id: &str) -> QueryResult<Vec<ExternalSeason>> {
-        todo!()
-    }
-
-    async fn episodes_for_season(&self, season_id: &str) -> QueryResult<Vec<ExternalEpisode>> {
-        todo!()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::external::{ExternalMedia, ExternalQuery};
 
     #[tokio::test]
     async fn sanity_check_tmdb_works() {
-        let provider = TMDBMetadataProvider::new("38c372f5bc572c8aadde7a802638534e".into());
-        let provider_shows: TMDBMetadataProviderRef<TvShows> = TMDBMetadataProviderRef {
-            provider,
-            _key: PhantomData,
-        };
+        let provider = TMDBMetadataProvider::new("38c372f5bc572c8aadde7a802638534e");
+        let provider_shows: MetadataProviderOf<TvShows> = provider.tv_shows();
 
-        provider_shows
+        let metadata = provider_shows
             .search("letterkenny", None)
             .await
             .expect("search results should exist");
+
+        let letterkenny = ExternalMedia {
+            external_id: "65798".into(),
+            title: "Letterkenny".into(),
+            description: Some("Letterkenny follows Wayne, a good-ol’ country boy in Letterkenny, Ontario trying to protect his homegrown way of life on the farm, against a world that is constantly evolving around him. The residents of Letterkenny belong to one of three groups: Hicks, Skids, and Hockey Players. The three groups are constantly feuding with each other over seemingly trivial matters; often ending with someone getting their ass kicked.".into()),
+            release_date: None, 
+            posters: vec!["/yvQGoc9GGTfOyPty5ASShT9tPBD.jpg".into()], 
+            backdrops: vec!["/wdHK7RZNIGfskbGCIusSKN3vto6.jpg".into()], 
+            genres: vec!["Comedy".into()], 
+            rating: Some(8.5), 
+            duration: None
+        };
+
+        assert_eq!(metadata, vec![letterkenny]);
     }
 }

--- a/dim/src/external/tmdb/mod.rs
+++ b/dim/src/external/tmdb/mod.rs
@@ -32,6 +32,8 @@ impl TMDBClientRequestError {
 
 #[cfg(test)]
 mod tests {
+    use chrono::{Datelike, Timelike};
+
     use super::*;
     use crate::external::{ExternalMedia, ExternalQuery};
 
@@ -45,11 +47,27 @@ mod tests {
             .await
             .expect("search results should exist");
 
+        let dt = chrono::Utc::now()
+            .with_day(7)
+            .unwrap()
+            .with_month(2)
+            .unwrap()
+            .with_year(2016)
+            .unwrap()
+            .with_minute(0)
+            .unwrap()
+            .with_second(0)
+            .unwrap()
+            .with_nanosecond(0)
+            .unwrap()
+            .with_hour(0)
+            .unwrap();
+
         let letterkenny = ExternalMedia {
             external_id: "65798".into(),
             title: "Letterkenny".into(),
             description: Some("Letterkenny follows Wayne, a good-ol’ country boy in Letterkenny, Ontario trying to protect his homegrown way of life on the farm, against a world that is constantly evolving around him. The residents of Letterkenny belong to one of three groups: Hicks, Skids, and Hockey Players. The three groups are constantly feuding with each other over seemingly trivial matters; often ending with someone getting their ass kicked.".into()),
-            release_date: None, 
+            release_date: Some(dt), 
             posters: vec!["/yvQGoc9GGTfOyPty5ASShT9tPBD.jpg".into()], 
             backdrops: vec!["/wdHK7RZNIGfskbGCIusSKN3vto6.jpg".into()], 
             genres: vec!["Comedy".into()], 

--- a/dim/src/external/tmdb/mod.rs
+++ b/dim/src/external/tmdb/mod.rs
@@ -1,0 +1,415 @@
+// #![deny(warnings)]
+
+use std::future::Future;
+use std::marker::PhantomData;
+
+use async_trait::async_trait;
+
+use displaydoc::Display;
+
+use tokio::sync::broadcast;
+
+use parking_lot::RwLock;
+
+use super::{Result as QueryResult, *};
+use core::result::Result;
+
+/// The User-Agent is generated from the package name "dim" and the version so "dim/0.x.y.z"
+pub const APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
+/// The base url used to access TMDB;
+pub const TMDB_BASE_URL: &str = "https://api.themoviedb.org/3";
+
+// -- TMDB API Data Models
+
+#[derive(Deserialize, Clone, Debug)]
+struct SearchResponse {
+    results: Vec<Option<TMDBMediaObject>>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct TMDBMediaObject {
+    pub id: u64,
+    #[serde(rename(deserialize = "title", deserialize = "name"))]
+    pub title: String,
+    #[serde(rename(deserialize = "release_date", deserialize = "first_air_date"))]
+    pub release_date: Option<String>,
+    pub overview: Option<String>,
+    pub vote_average: Option<f64>,
+    pub poster_path: Option<String>,
+    pub backdrop_path: Option<String>,
+    pub genre_ids: Option<Vec<u64>>,
+    #[serde(skip_deserializing)]
+    pub genres: Vec<String>,
+    pub runtime: Option<u64>,
+}
+
+// -- TMDBClient
+
+#[derive(Debug, Display, Clone, thiserror::Error)]
+enum TMDBClientRequestError {
+    /// The body of a response was not value UTF-8.
+    InvalidUTF8Body,
+    /// the error comes from reqwest.
+    ReqwestError(#[from] Arc<reqwest::Error>),
+}
+
+/// Internal TMDB client type used for building and making requests.
+struct TMDBClient {
+    provider: TMDBMetadataProvider,
+}
+
+impl TMDBClient {
+    async fn genre_detail(&self, genre_id: u64) -> Result<String, TMDBClientRequestError> {
+        let url = format!("{TMDB_BASE_URL}/genre/{genre_id}/list");
+        let args: Vec<_> = vec![("api_key", self.provider.api_key.as_ref())]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        let req = self
+            .provider
+            .http_client
+            .get(url)
+            .query(&args)
+            .send()
+            .await
+            .map_err(|err| TMDBClientRequestError::ReqwestError(Arc::new(err)))?;
+
+        let body = req
+            .bytes()
+            .await
+            .map_err(|err| TMDBClientRequestError::ReqwestError(Arc::new(err)))?;
+
+        std::str::from_utf8(&body)
+            .map_err(|_| TMDBClientRequestError::InvalidUTF8Body)
+            .map(|st| st.to_string())
+    }
+
+    async fn search(
+        &self,
+        media_type: MediaType,
+        title: &str,
+        year: Option<i32>,
+    ) -> Result<String, TMDBClientRequestError> {
+        let url = format!("{TMDB_BASE_URL}/search/{media_type}");
+        let args: Vec<_> = vec![
+            ("api_key", self.provider.api_key.as_ref()),
+            ("language", "en-US"),
+            ("query", title),
+            ("page", "1"),
+            ("include_adult", "false"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .chain(
+            year.into_iter()
+                .map(|n| ("year".to_string(), n.to_string())),
+        )
+        .collect();
+
+        let req = self
+            .provider
+            .http_client
+            .get(url)
+            .query(&args)
+            .send()
+            .await
+            .map_err(|err| TMDBClientRequestError::ReqwestError(Arc::new(err)))?;
+
+        let body = req
+            .bytes()
+            .await
+            .map_err(|err| TMDBClientRequestError::ReqwestError(Arc::new(err)))?;
+
+        std::str::from_utf8(&body)
+            .map_err(|_| TMDBClientRequestError::InvalidUTF8Body)
+            .map(|st| st.to_string())
+    }
+}
+
+// -- cache control
+
+/// The type of our hashmap we use for caching.
+///
+/// The current implementation is using [flurry](https://docs.rs/flurry)
+///
+type CacheMap = Arc<dashmap::DashMap<CacheKey, RwLock<Option<CacheValue>>>>;
+
+/// The key type used within the [CacheMap], refers to [CacheValue]s.
+///
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum CacheKey {
+    /// A search result
+    Search { title: String, year: Option<i32> },
+}
+
+type PendingRequestTx = broadcast::Sender<Result<Arc<str>, TMDBClientRequestError>>;
+
+/// The value type used within the [CacheMap], refered to by [CacheKey]s.
+#[derive(Clone)]
+enum CacheValue {
+    /// The request responsible for fulfilling this data is currently in flight.
+    RequestInFlight { tx: PendingRequestTx },
+    /// The responses body as UTF-8, cached.
+    Body { text: Arc<str> },
+}
+
+impl CacheValue {
+    /// get the data out of the value, if it is still pending, wait for it and turn errors into None.
+    async fn data(&self) -> Option<Arc<str>> {
+        match self {
+            CacheValue::RequestInFlight { tx } => {
+                tx.subscribe().recv().await.map(|o| o.ok()).ok().flatten()
+            }
+            CacheValue::Body { text } => Some(Arc::clone(text)),
+        }
+    }
+}
+
+// -- TMDBMetadataProvider
+
+/// TMDB Metadata Provider implements `ExternalQuery` and handles request coalescing and caching locally.
+pub struct TMDBMetadataProvider {
+    api_key: Arc<str>,
+    http_client: reqwest::Client,
+    cache: CacheMap,
+}
+
+impl Clone for TMDBMetadataProvider {
+    fn clone(&self) -> Self {
+        Self {
+            api_key: self.api_key.clone(),
+            http_client: self.http_client.clone(),
+            cache: self.cache.clone(),
+        }
+    }
+}
+
+impl TMDBMetadataProvider {
+    pub fn new(api_key: String) -> Self {
+        let http_client = reqwest::ClientBuilder::new()
+            .user_agent(APP_USER_AGENT)
+            .build()
+            .expect("building this client should never fail.");
+
+        let api_key: Arc<str> = api_key.into_boxed_str().into();
+
+        Self {
+            api_key,
+            http_client,
+            cache: Default::default(),
+        }
+    }
+
+    /// insert a default [CacheValue] if the slot at a given key is not present.
+    fn insert_value_if_empty(&self, key: &CacheKey) -> (CacheValue, bool) {
+        // grab the entry or instert RwLock::new(None) if not present.
+        let entry = self.cache.entry(key.clone()).or_default();
+
+        // fast path: cache hits, no writers and the value is present.
+        {
+            let read_guard = entry.value().read();
+            if let Some(value) = read_guard.as_ref() {
+                return (value.clone(), false);
+            }
+        }
+
+        // slow path: get a write guard, if the slot is still uninit when we acquire; initialize it.s
+        let mut slot = entry.value().write();
+
+        match slot.as_ref() {
+            // someone initialized the slot before we got the write guard, use their value.
+            Some(value) => (value.clone(), false),
+            // we're still first, initialize the value and keep going.
+            None => {
+                let (tx, _) = broadcast::channel(1);
+                let value = CacheValue::RequestInFlight { tx };
+                slot.replace(value.clone());
+                (value, true)
+            }
+        }
+    }
+
+    /// perform request coalescing; when two futures are made with the same key the duplicates wait for the original to broadcast the results.
+    async fn coalesce_request<F, Fut>(
+        &self,
+        key: &CacheKey,
+        make_request_future: F,
+    ) -> Result<Arc<str>, Error>
+    where
+        F: FnOnce(TMDBClient) -> Fut,
+        Fut: Future<Output = Result<Arc<str>, TMDBClientRequestError>> + Send + 'static,
+    {
+        let (value, we_own_future) = { self.insert_value_if_empty(key) };
+
+        match (we_own_future, value) {
+            // only if we own the future that was spawned should we upate the
+            // value once we get the response.
+            (true, CacheValue::RequestInFlight { tx }) => {
+                let client = TMDBClient {
+                    provider: self.clone(),
+                };
+
+                let tx_ = tx.clone();
+                let fut = make_request_future(client);
+                tokio::spawn(async move {
+                    let output = fut.await;
+                    let _ = tx_.send(output);
+                });
+
+                match { CacheValue::RequestInFlight { tx } }.data().await {
+                    Some(text) => {
+                        let body = Arc::clone(&text);
+
+                        let _ = match self.cache.get(key) {
+                            Some(rw_lock) => rw_lock.write().replace(CacheValue::Body { text }),
+                            None => unreachable!("slot was None when original task got its result"),
+                        };
+
+                        Ok(body)
+                    }
+                    // if an error was yeeted back during the request then purge the cache entry.
+                    None => {
+                        // clear the cache for values that could not be populated.
+                        let _ = self.cache.remove(&key);
+                        Err(Error::Timeout)
+                    }
+                }
+            }
+
+            (_, value) => value.data().await.ok_or(Error::Timeout),
+        }
+    }
+
+    async fn search(
+        &self,
+        title: &str,
+        year: Option<i32>,
+        media_type: MediaType,
+    ) -> QueryResult<Vec<ExternalMedia>> {
+        let title = title.to_string();
+        let key = CacheKey::Search {
+            title: title.clone(),
+            year,
+        };
+
+        let st = self
+            .coalesce_request(&key, |client| async move {
+                let body = client
+                    .search(media_type, &title, year)
+                    .await
+                    .map(|st| st.into_boxed_str().into());
+
+                body
+            })
+            .await?;
+
+        let search = serde_json::from_str::<SearchResponse>(&st).map_err(Error::other)?;
+
+        for media in search.results.iter_mut() {
+            if let Some(media_object) = media {
+                let key = CacheKey::GenreDetail {
+                    id: media_object.genre_ids,
+                };
+
+                self.coalesce_request(key, make_request_future)
+            }
+        }
+
+        todo!()
+    }
+
+    async fn search_by_id(&self, external_id: &str) -> QueryResult<ExternalMedia> {
+        todo!()
+    }
+
+    async fn actors(&self, external_id: &str) -> QueryResult<Vec<ExternalActor>> {
+        todo!()
+    }
+}
+
+// -- TMDBMetadataProviderRef<T>
+
+/// Used to key [TMDBMetadataProviderRef] to search for TV shows, compliments [Movies].
+pub struct TvShows;
+
+/// Used to key [TMDBMetadataProviderRef] to search for movies, compliments [TvShows].
+pub struct Movies;
+
+/// An instance of [TMDBMetadataProvider] with a generic parameter to infer the [MediaType] for searches.
+pub struct TMDBMetadataProviderRef<K>
+where
+    K: Send + Sync + 'static,
+{
+    pub provider: TMDBMetadataProvider,
+    _key: PhantomData<K>,
+}
+
+mod sealed {
+    use super::{MediaType, Movies, TvShows};
+
+    /// Used to associate a constant [MediaType] with another type.
+    pub trait AssocMediaTypeConst {
+        const MEDIA_TYPE: MediaType;
+    }
+
+    impl AssocMediaTypeConst for TvShows {
+        const MEDIA_TYPE: MediaType = MediaType::Tv;
+    }
+
+    impl AssocMediaTypeConst for Movies {
+        const MEDIA_TYPE: MediaType = MediaType::Tv;
+    }
+}
+
+#[async_trait]
+impl<K> ExternalQuery for TMDBMetadataProviderRef<K>
+where
+    K: sealed::AssocMediaTypeConst + Send + Sync + 'static,
+{
+    async fn search(&self, title: &str, year: Option<i32>) -> QueryResult<Vec<ExternalMedia>> {
+        self.provider.search(title, year, K::MEDIA_TYPE).await
+    }
+
+    async fn search_by_id(&self, external_id: &str) -> QueryResult<ExternalMedia> {
+        todo!()
+    }
+
+    async fn actors(&self, external_id: &str) -> QueryResult<Vec<ExternalActor>> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl<K> ExternalQueryShow for TMDBMetadataProviderRef<K>
+where
+    K: sealed::AssocMediaTypeConst + Send + Sync + 'static,
+{
+    async fn seasons_for_id(&self, external_id: &str) -> QueryResult<Vec<ExternalSeason>> {
+        todo!()
+    }
+
+    async fn episodes_for_season(&self, season_id: &str) -> QueryResult<Vec<ExternalEpisode>> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn sanity_check_tmdb_works() {
+        let provider = TMDBMetadataProvider::new("38c372f5bc572c8aadde7a802638534e".into());
+        let provider_shows: TMDBMetadataProviderRef<TvShows> = TMDBMetadataProviderRef {
+            provider,
+            _key: PhantomData,
+        };
+
+        provider_shows
+            .search("letterkenny", None)
+            .await
+            .expect("search results should exist");
+    }
+}

--- a/dim/src/external/tmdb/mod.rs
+++ b/dim/src/external/tmdb/mod.rs
@@ -89,7 +89,7 @@ mod tests {
             .unwrap();
 
         ExternalMedia {
-        external_id: "65798".into(),
+            external_id: "65798".into(),
             title: "Letterkenny".into(),
             description: Some("Letterkenny follows Wayne, a good-ol’ country boy in Letterkenny, Ontario trying to protect his homegrown way of life on the farm, against a world that is constantly evolving around him. The residents of Letterkenny belong to one of three groups: Hicks, Skids, and Hockey Players. The three groups are constantly feuding with each other over seemingly trivial matters; often ending with someone getting their ass kicked.".into()),
             release_date: Some(dt),

--- a/dim/src/external/tmdb/mod.rs
+++ b/dim/src/external/tmdb/mod.rs
@@ -96,7 +96,7 @@ mod tests {
             posters: vec!["/yvQGoc9GGTfOyPty5ASShT9tPBD.jpg".into()], 
             backdrops: vec!["/wdHK7RZNIGfskbGCIusSKN3vto6.jpg".into()], 
             genres: vec!["Comedy".into()], 
-            rating: Some(8.4),
+            rating: Some(8.3),
             duration: None
         }
     }

--- a/dim/src/external/tmdb/raw_client.rs
+++ b/dim/src/external/tmdb/raw_client.rs
@@ -1,0 +1,120 @@
+use std::future::Future;
+
+use serde::Deserialize;
+
+use crate::external::MediaSearchType;
+
+use super::{TMDBClientRequestError, TMDBMetadataProvider, TMDB_BASE_URL};
+
+// -- TMDB API Data Models
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct SearchResponse {
+    pub results: Vec<Option<TMDBMediaObject>>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct TMDBMediaObject {
+    pub id: u64,
+    #[serde(rename(deserialize = "title", deserialize = "name"))]
+    pub title: String,
+    #[serde(rename(deserialize = "release_date", deserialize = "first_air_date"))]
+    pub release_date: Option<String>,
+    pub overview: Option<String>,
+    pub vote_average: Option<f64>,
+    pub poster_path: Option<String>,
+    pub backdrop_path: Option<String>,
+    pub genre_ids: Option<Vec<u64>>,
+    #[serde(skip_deserializing)]
+    pub genres: Vec<String>,
+    pub runtime: Option<u64>,
+}
+
+#[derive(Deserialize)]
+pub struct GenreList {
+    pub genres: Vec<Genre>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Genre {
+    pub id: u64,
+    pub name: String,
+}
+
+// -- TMDBClient
+
+/// Internal TMDB client type used for building and making requests.
+pub(super) struct TMDBClient {
+    pub provider: TMDBMetadataProvider,
+}
+
+impl TMDBClient {
+    fn make_request<A, T>(
+        &self,
+        args: A,
+        path: String,
+    ) -> impl Future<Output = Result<String, TMDBClientRequestError>>
+    where
+        A: IntoIterator<Item = (T, T)>,
+        T: ToString,
+    {
+        let url = format!("{TMDB_BASE_URL}{path}");
+        let args: Vec<_> = args
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        let request = self.provider.http_client.get(url).query(&args);
+
+        async move {
+            let response = request
+                .send()
+                .await
+                .map_err(TMDBClientRequestError::reqwest)?;
+
+            let body = response
+                .bytes()
+                .await
+                .map_err(TMDBClientRequestError::reqwest)?;
+
+            std::str::from_utf8(&body)
+                .map_err(|_| TMDBClientRequestError::InvalidUTF8Body)
+                .map(|st| st.to_string())
+        }
+    }
+
+    pub async fn genre_list(
+        &self,
+        media_type: MediaSearchType,
+    ) -> Result<String, TMDBClientRequestError> {
+        self.make_request(
+            vec![("api_key", self.provider.api_key.as_ref())],
+            format!("/genre/{media_type}/list"),
+        )
+        .await
+    }
+
+    pub async fn search(
+        &self,
+        media_type: MediaSearchType,
+        title: &str,
+        year: Option<i32>,
+    ) -> Result<String, TMDBClientRequestError> {
+        let args = vec![
+            ("api_key", self.provider.api_key.as_ref()),
+            ("language", "en-US"),
+            ("query", title),
+            ("page", "1"),
+            ("include_adult", "false"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .chain(
+            year.into_iter()
+                .map(|n| ("year".to_string(), n.to_string())),
+        );
+
+        self.make_request(args, format!("/search/{media_type}"))
+            .await
+    }
+}


### PR DESCRIPTION
## Todo

- [x] request coalescing
- [x] write new TMDB client
- [x] cache eviction policy
- [x] client-side in-flight request limiting
- [x] proper error propagation

## Notable types

### `struct TMDBMetadataProvider`

`TMDBMetadataProvider` is the main type used to provide a centralized store of the response-cache, the shared reqwest Client type, and the API key.

`TMDBMetadataProvider` does not implement `ExternalQuery` or `ExternalQueryShow` since it is a unified cache and so the media type being searched for must be provided explicitly.

However since the `ExternalQuery` trait does not allow passing this in the method arguments we have another type `MetadataProviderOf<K>` which is used to parameterise the search type.  `TMDBMetadataProvider::movies` and `TMDBMetadataProvider::tv_shows` will each produce `MetadataProviderOf<Movies>` and `MetadataProviderOf<TvShows>` respectively. and these are the types for which `ExternalQuery` is implemented on.

### `struct TMDBClient`

This is a private type that is the API wrapper for the TMDB REST API, it only contains a reference to a provider instance for access of the API key, and nothing else. It has associated methods which each correspond to some kind of TMDB API endpoint/operation.

## Example

```rs
let provider = TMDBMetadataProvider::new("API_KEY");

let breaking_bad/* : ExternalMedia */ = provider.tv_shows().search("breaking bad", None).await.expect("I am the one who panics.");

let el_camino/* : ExternalMedia */ = provider.movies().search("El Camino: A Breaking Bad Movie", Some(2019)).await.expect("this is the way.");

// only one http request will be made. the rest of the futures will wait on the shared result of the first one.
let _ = futures::join!(
    provider.movies().search("baby driver", None)),
    provider.movies().search("baby driver", None)),
    provider.movies().search("baby driver", None)),
    provider.movies().search("baby driver", None)),
).await;
```