### PR TITLE
Update README.md to align with new licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cargo run --release
 
 ## License
 
-Dim is licensed under the GPLv2 license ([LICENSE.md](LICENSE.md) or http://opensource.org/licenses/GPL-2.0)
+Dim is licensed under the AGPLv3 license (see [LICENSE.md](LICENSE.md) or https://opensource.org/licenses/AGPL-3.0)
 
 ## Screenshots
 


### PR DESCRIPTION
Current readme still says dim is licenced under GPLv2.

This commit changes it to follow the new licence, AGPLv3.