### PR TITLE
feature: allow clients to request dim to compute and attach accent colors

### DIFF
--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -63,6 +63,8 @@ tracing-tree = "0.2.0"
 thiserror = "1.0.30"
 displaydoc = "0.2.3"
 fuzzy-matcher = "0.3.7"
+dominant_color = "0.3.0"
+image = "0.24.3"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/src/routes/statik.rs
+++ b/dim/src/routes/statik.rs
@@ -31,6 +31,8 @@ pub mod filters {
         struct QueryArgs {
             w: Option<u32>,
             h: Option<u32>,
+            #[serde(default)]
+            attach_accents: bool,
         }
 
         let metadata_path = crate::core::METADATA_PATH.get().unwrap();
@@ -42,8 +44,15 @@ pub mod filters {
             .and(with_state(metadata_path.clone()))
             .and(with_state(conn))
             .and_then(
-                |x, QueryArgs { w, h }: QueryArgs, meta_path, conn| async move {
-                    super::get_image(x, w, h, meta_path, conn)
+                |x,
+                 QueryArgs {
+                     w,
+                     h,
+                     attach_accents,
+                 }: QueryArgs,
+                 meta_path,
+                 conn| async move {
+                    super::get_image(x, w, h, meta_path, conn, attach_accents)
                         .await
                         .map_err(|e| reject::custom(e))
                 },
@@ -136,6 +145,7 @@ pub async fn get_image(
     _resize_h: Option<u32>,
     meta_path: String,
     conn: database::DbConnection,
+    attach_accents: bool,
 ) -> Result<impl warp::Reply, errors::DimError> {
     let mut file_path = PathBuf::from(&meta_path);
     file_path.push(path.as_str());
@@ -152,6 +162,8 @@ pub async fn get_image(
     */
 
     let mut tx = conn.read().begin().await?;
+    // FIXME (val): return not yet available error here as a hint that in the future this URL will
+    // return 200 OK.
     if !Path::new(&file_path).exists() {
         if let Ok(x) = asset::Asset::get_url_by_file(&mut tx, &url_path).await {
             insert_into_queue(x, 5).await;
@@ -160,12 +172,36 @@ pub async fn get_image(
 
     let image = tokio::fs::read(file_path).await.ok();
 
+    let accents = match (image.as_ref(), attach_accents) {
+        (Some(data), true) => {
+            if let Ok(image) = image::load_from_memory(&data) {
+                Some(
+                    dominant_color::get_colors(image.as_bytes(), false)
+                        .chunks_exact(3)
+                        .map(|rgb| match rgb {
+                            [r, g, b] => format!("#{r:02x}{g:02x}{b:02x}"),
+                            _ => unreachable!(),
+                        })
+                        .collect::<Vec<_>>()
+                        .join(","),
+                )
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+
     if let Some(data) = image {
-        return warp::http::Response::builder()
+        let mut resp = warp::http::Response::builder()
             .status(StatusCode::OK)
-            .header("ContentType", "image/jpeg")
-            .body(data)
-            .map_err(|_| errors::DimError::NotFoundError);
+            .header("ContentType", "image/jpeg");
+
+        if let Some(accents) = accents {
+            resp = resp.header("X-IMAGE-ACCENTS", accents);
+        }
+
+        return resp.body(data).map_err(|_| errors::DimError::NotFoundError);
     }
 
     Err(errors::DimError::NotFoundError)


### PR DESCRIPTION
This PR adds a feature where when requesting a image asset, a client can attach the `attach_accents=true` URI param, which will hint the backend to compute the accent colors of the image being requested. These colors are then converted to hex, concatenated with `,` as a delimiter and injected as a header into the response. The header is `x-image-accents`.

In the future it would be a good idea to cache the accents in memory.