### PR TITLE
Using which crate instead of symlinking ffmpeg

### DIFF
--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -63,6 +63,7 @@ tracing-tree = "0.2.0"
 thiserror = "1.0.30"
 displaydoc = "0.2.3"
 fuzzy-matcher = "0.3.7"
+which = "4.2.5"
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/src/streaming/mod.rs
+++ b/dim/src/streaming/mod.rs
@@ -1,15 +1,15 @@
 pub mod ffprobe;
-
+use which::which;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-use crate::utils::ffpath;
+// use crate::utils::ffpath;
 
 lazy_static::lazy_static! {
     pub static ref STREAMING_SESSION: Arc<RwLock<HashMap<String, HashMap<String, String>>>> = Arc::new(RwLock::new(HashMap::new()));
-    pub static ref FFMPEG_BIN: &'static str = Box::leak(ffpath("utils/ffmpeg").into_boxed_str());
-    pub static ref FFPROBE_BIN: &'static str = Box::leak(ffpath("utils/ffprobe").into_boxed_str());
+    pub static ref FFMPEG_BIN: &'static str = Box::leak(which("ffmpeg").expect("Could not find ffmpeg in PATH").to_string_lossy().into_owned().into_boxed_str());
+    pub static ref FFPROBE_BIN: &'static str = Box::leak(which("ffprobe").expect("Could not find ffprobe in PATH").to_string_lossy().into_owned().into_boxed_str());
 }
 
 use std::process::Command;


### PR DESCRIPTION
I was looking at #453 and wondered if this would work. We should also be able to specify a separate ffmpeg binary. Which is supposed to work on Windows, so it should solve that problem.