### PR TITLE
Fix invite token input not showing up when creating a new account

### DIFF
--- a/dim/src/routes/auth.rs
+++ b/dim/src/routes/auth.rs
@@ -54,19 +54,6 @@ pub mod filters {
             })
     }
 
-    pub fn admin_exists(
-        conn: DbConnection,
-    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-        warp::path!("api" / "v1" / "auth" / "admin_exists")
-            .and(warp::get())
-            .and(with_db(conn))
-            .and_then(|conn: DbConnection| async move {
-                super::admin_exists(conn)
-                    .await
-                    .map_err(|e| reject::custom(e))
-            })
-    }
-
     pub fn register(
         conn: DbConnection,
     ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {

--- a/ui/src/actions/auth.js
+++ b/ui/src/actions/auth.js
@@ -222,7 +222,7 @@ export const delAccount = (password) => async (dispatch, getState) => {
 
 export const checkAdminExists = () => async (dispatch) => {
   try {
-    const res = await fetch("/api/v1/auth/admin_exists");
+    const res = await fetch("/api/v1/host/admin_exists");
 
     if (res.status !== 200) {
       return dispatch({


### PR DESCRIPTION
Fix bug where the invite token input wasn't showing up due to the route being renamed from /api/v1/auth/admin_exists -> /api/v1/host/admin_exists.
And remove the old /api/v1/auth/admin_exists route that seem to be unused.