### PR TITLE
Add sqlite cdc event pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "retry-block",
+ "rusqlite",
  "rust-embed",
  "serde",
  "serde_derive",
@@ -815,6 +816,18 @@ dependencies = [
  "smallvec",
  "threadpool",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2310,6 +2323,21 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "image",
  "itertools",
  "lazy_static",
+ "libsqlite3-sys",
  "nightfall",
  "nix 0.20.0",
  "notify",

--- a/database/migrations/20220924000853_propagate-delete-assets.sql
+++ b/database/migrations/20220924000853_propagate-delete-assets.sql
@@ -1,0 +1,13 @@
+-- Adds a delete trigger to both media_posters and media_backdrops which
+-- ensure that the asset erased is also deleted from the assets table
+CREATE TRIGGER IF NOT EXISTS media_backdrops_propagate
+AFTER DELETE ON media_backdrops
+FOR EACH ROW BEGIN
+    DELETE FROM assets WHERE id = old.asset_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS media_posters_propagate
+AFTER DELETE ON media_posters
+FOR EACH ROW BEGIN
+    DELETE FROM assets WHERE id = old.asset_id;
+END;

--- a/database/src/library.rs
+++ b/database/src/library.rs
@@ -71,6 +71,8 @@ pub struct Library {
     /// moment only `movie` and `tv` are supported
     // TODO: support mixed content, music
     pub media_type: MediaType,
+    /// Is library hidden?
+    pub hidden: bool,
 }
 
 impl Library {
@@ -80,7 +82,7 @@ impl Library {
     /// This method will not return the locations indexed for this library, if you need those you
     /// must query for them separately.
     pub async fn get_all(conn: &mut crate::Transaction<'_>) -> Vec<Self> {
-        sqlx::query!(r#"SELECT id, name, media_type as "media_type: MediaType" FROM library WHERE NOT hidden"#)
+        sqlx::query!(r#"SELECT id, name, media_type as "media_type: MediaType", hidden as "hidden: bool" FROM library WHERE NOT hidden"#)
             .fetch_all(&mut *conn)
             .await
             .unwrap_or_default()
@@ -89,6 +91,7 @@ impl Library {
                 id: x.id,
                 name: x.name,
                 media_type: x.media_type,
+                hidden: x.hidden,
                 locations: vec![],
             })
             .collect()
@@ -118,7 +121,7 @@ impl Library {
         lib_id: i64,
     ) -> Result<Self, DatabaseError> {
         let library = sqlx::query!(
-            r#"SELECT id, name, media_type as "media_type: MediaType" FROM library
+            r#"SELECT id, name, media_type as "media_type: MediaType", hidden as "hidden: bool" FROM library
             WHERE id = ?"#,
             lib_id
         )
@@ -137,6 +140,7 @@ impl Library {
             id: library.id,
             name: library.name,
             media_type: library.media_type,
+            hidden: library.hidden,
             locations,
         })
     }

--- a/database/src/media.rs
+++ b/database/src/media.rs
@@ -300,6 +300,22 @@ impl Media {
                 .rows_affected() as usize,
         )
     }
+
+    /// Get compact representation of a media object. This returns the library_id and
+    /// media_type of the media object.
+    pub async fn get_compact(
+        tx: &mut crate::Transaction<'_>,
+        id: i64,
+    ) -> Result<(i64, MediaType), DatabaseError> {
+        type Record = (i64, MediaType);
+
+        Ok(sqlx::query_as::<_, Record>(
+            r#"SELECT library_id, media_type AS "media_type: _" FROM _tblmedia WHERE id = ?"#,
+        )
+        .bind(id)
+        .fetch_one(&mut *tx)
+        .await?)
+    }
 }
 
 impl Into<super::tv::TVShow> for Media {

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -74,6 +74,7 @@ url = "2.2.2"
 retry-block = "1.0.0"
 hyper = "0.14.20"
 rusqlite = { version = "0.27.0", features = ["hooks"] }
+libsqlite3-sys = { version = "^0.24.0" }
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -73,6 +73,7 @@ new_xtra = { package = "xtra", git = "https://github.com/Restioson/xtra", featur
 url = "2.2.2"
 retry-block = "1.0.0"
 hyper = "0.14.20"
+rusqlite = { version = "0.27.0", features = ["hooks"] }
 
 [build-dependencies]
 fs_extra = "1.1.0"

--- a/dim/src/core.rs
+++ b/dim/src/core.rs
@@ -118,7 +118,7 @@ pub async fn warp_core(
         /* library routes */
         routes::library::filters::library_get(conn.clone()),
         routes::library::filters::library_post(conn.clone(), event_tx.clone()),
-        routes::library::filters::library_delete(conn.clone(), event_tx.clone()),
+        routes::library::filters::library_delete(conn.clone()),
         routes::library::filters::library_get_self(conn.clone()),
         routes::library::filters::get_all_of_library(conn.clone()),
         routes::library::filters::get_all_unmatched_media(conn.clone()),

--- a/dim/src/events/mod.rs
+++ b/dim/src/events/mod.rs
@@ -1,0 +1,145 @@
+use tokio::sync::OwnedMutexGuard;
+use sqlx::SqliteConnection;
+use rusqlite::Connection;
+use rusqlite::hooks::Action;
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+pub trait Reactor {
+    type Error;
+
+    fn react(&mut self, event: Event) -> Result<(), Self::Error>;
+}
+
+#[derive(Clone)]
+struct Context {
+    uncommited_buffer: Arc<Mutex<Vec<Event>>>,
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self { 
+            uncommited_buffer: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+pub struct ReactorCore {
+    hook_ctx: Context,
+}
+
+impl ReactorCore {
+    pub fn new() -> Self {
+        Self  {
+            hook_ctx: Context::new()
+        }
+    }
+
+    pub async fn register(&self, lock: &mut OwnedMutexGuard<SqliteConnection>) {
+        let mut handle_lock = lock.lock_handle().await.unwrap();
+        let handle = handle_lock.as_raw_handle();
+
+        // SAFETY: Its safe to construct the connection from a handle because we lock it above
+        // which ensures the access is synchronized.
+        let conn = unsafe { Connection::from_handle(handle.as_ptr()).unwrap() };
+
+        conn.update_hook(Some(self.update_hook()));
+        conn.commit_hook(Some(self.commit_hook()));
+        conn.rollback_hook(Some(self.rollback_hook()));
+
+        // SAFETY: We need to forget `conn` otherwise its destructor runs and our hooks get
+        // deleted.
+        core::mem::forget(conn);
+    }
+
+    pub async fn react<E>(self, reactor: impl Reactor<Error = E>) {
+        return;
+    }
+
+    pub fn update_hook(&self) -> impl FnMut(Action, &str, &str, i64) + Send + 'static {
+        let context = self.hook_ctx.clone();
+
+        // NOTE: This callback must complete as quickly as it can as it is called directly after
+        // our database operations and not asynchronously. Sqlite will wait for this function to
+        // complete executing and then the database operation will also be completed. If this
+        // function never ends, the clients operating on the database will lock as well.
+        move |action, _, table, rowid| {
+            let Ok(source_table): Result<Table, _> = table.try_into() else {
+                // Early return because the source table is not something we are watching.
+                return;
+            };
+
+            // Ignore any events which are invalid
+            if matches!(action, Action::UNKNOWN) {
+                return;
+            }
+
+            let mut buffer = context.uncommited_buffer.lock().unwrap();
+
+            buffer.push(Event {
+                id: rowid,
+                table: source_table,
+                event_type: action.into(),
+            });
+        }
+    }
+
+    pub fn commit_hook(&self) -> impl FnMut() -> bool + Send + 'static {
+        || { true }
+    }
+
+    pub fn rollback_hook(&self) -> impl FnMut() + Send + 'static {
+        let context = self.hook_ctx.clone();
+
+        // NOTE: If we get a rollback, we automatically assume that our current buffer of
+        // uncommited events is dirty and will not be applied to the real database, thus we can
+        // just clear them.
+        move || {
+            let mut buffer = context.uncommited_buffer.lock().unwrap();
+            buffer.clear();
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Table {
+    Library,
+    Media,
+}
+
+impl TryFrom<&str> for Table {
+    type Error = ();
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "library" => Ok(Self::Library),
+            "media" => Ok(Self::Media),
+            _ => Err(())
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum EventType {
+    Insert,
+    Update,
+    Delete,
+}
+
+impl From<Action> for EventType {
+    fn from(action: Action) -> EventType {
+        match action {
+            Action::SQLITE_INSERT => EventType::Insert,
+            Action::SQLITE_UPDATE => EventType::Update,
+            Action::SQLITE_DELETE => EventType::Delete,
+            _ => unimplemented!()
+        }
+    }
+}
+
+pub struct Event {
+    pub id: i64,
+    pub event_type: EventType,
+    pub table: Table,
+}

--- a/dim/src/external/tmdb/cache_control.rs
+++ b/dim/src/external/tmdb/cache_control.rs
@@ -101,7 +101,7 @@ impl CacheEviction {
                 let items = self.evict();
                 let duration = now.elapsed().as_millis();
 
-                tracing::info!(
+                tracing::debug!(
                     items = items,
                     duration_ms = duration,
                     "tmdb cache eviction finished."

--- a/dim/src/lib.rs
+++ b/dim/src/lib.rs
@@ -32,14 +32,14 @@ pub mod core;
 pub mod errors;
 /// Module contains our external api interfaces
 pub mod external;
-/// Sqlite CDC implementation
-pub mod events;
 /// Contains the code for fetching assets like posters and stills.
 pub mod fetcher;
 /// Inspect api for Result type
 pub mod inspect;
 /// Contains our custom logger for rocket
 pub mod logger;
+/// Sqlite CDC implementation
+pub mod reactor;
 /// Contains all of the routes exposed by the webapi.
 pub mod routes;
 /// New generation scanner infrastructure.

--- a/dim/src/lib.rs
+++ b/dim/src/lib.rs
@@ -32,6 +32,8 @@ pub mod core;
 pub mod errors;
 /// Module contains our external api interfaces
 pub mod external;
+/// Sqlite CDC implementation
+pub mod events;
 /// Contains the code for fetching assets like posters and stills.
 pub mod fetcher;
 /// Inspect api for Result type

--- a/dim/src/main.rs
+++ b/dim/src/main.rs
@@ -84,25 +84,19 @@ fn main() {
     nightfall::profiles::profiles_init(crate::streaming::FFMPEG_BIN.to_string());
 
     let async_main = async move {
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+
         // Before we start making DB-calls we need to initialize our CDC pipeline.
+        let reactor = dim::reactor::handler::EventReactor::new().with_websocket(event_tx.clone());
+
         {
             let pool = database::get_conn().await.unwrap();
             let mut lock = pool.writer().lock_owned().await;
-            dim::events::ReactorCore::new().register(&mut lock).await;
+            let mut reactor_core = dim::reactor::ReactorCore::new();
+            reactor_core.register(&mut lock).await;
 
-            let mut tx = database::write_tx(&mut lock).await.unwrap();
-
-            database::library::InsertableLibrary {
-                name: "abccc".into(),
-                locations: vec![],
-                media_type: database::library::MediaType::Movie,
-            }.insert(&mut tx).await.unwrap();
-
-
-            tx.commit().await.unwrap();
+            tokio::spawn(reactor_core.react(reactor));
         }
-
-        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let stream_manager = nightfall::StateManager::new(
             &mut Tokio::Global,

--- a/dim/src/reactor/handler/error.rs
+++ b/dim/src/reactor/handler/error.rs
@@ -1,0 +1,16 @@
+use displaydoc::Display;
+use thiserror::Error;
+
+#[derive(Debug, Display, Error)]
+pub enum Error {
+    /// Failed to dispatch event to websocket clients: {0:?}
+    EventDispatch(tokio::sync::mpsc::error::SendError<String>),
+    /// Failed to open read-only transaction: {0:?}
+    ReadTransaction(sqlx::Error),
+    /// Failed to query library: {0:?}
+    LibraryQuery(database::DatabaseError),
+    /// Failed to query asset: {0:?}
+    AssetQuery(database::DatabaseError),
+    /// Failed to query media: {0:?}
+    MediaQuery(database::DatabaseError),
+}

--- a/dim/src/reactor/handler/mod.rs
+++ b/dim/src/reactor/handler/mod.rs
@@ -1,0 +1,65 @@
+use super::types::EventType;
+use super::types::Table;
+use super::Event;
+use super::Reactor;
+use crate::core::EventTx;
+
+use events::Message;
+use events::PushEventType;
+
+use async_trait::async_trait;
+
+pub type Error = std::convert::Infallible;
+
+pub struct EventReactor {
+    ws_event_tx: Option<EventTx>,
+}
+
+impl EventReactor {
+    pub fn new() -> Self {
+        Self { ws_event_tx: None }
+    }
+
+    pub fn with_websocket(mut self, event_tx: EventTx) -> Self {
+        self.ws_event_tx = Some(event_tx);
+        self
+    }
+
+    pub fn handle_library(&mut self, event: Event) -> Result<(), Error> {
+        let Some(event_tx) = self.ws_event_tx.as_mut() else {
+            return Ok(());
+        };
+
+        assert_eq!(event.table, Table::Library);
+
+        // TODO (val): should we also handle updates to the library? Such as renaming etc.
+        let event_type = match event.event_type {
+            EventType::Insert => PushEventType::EventNewLibrary,
+            EventType::Delete => PushEventType::EventRemoveLibrary,
+            _ => return Ok(()),
+        };
+
+        let event = Message {
+            id: event.id,
+            event_type,
+        };
+
+        event_tx
+            .send(serde_json::to_string(&event).expect("Serializing event should never fail"))
+            .unwrap();
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Reactor for EventReactor {
+    type Error = Error;
+
+    async fn react(&mut self, event: Event) -> Result<(), Self::Error> {
+        match event.table {
+            Table::Library => self.handle_library(event),
+            _ => return Ok(()),
+        }
+    }
+}

--- a/dim/src/reactor/handler/mod.rs
+++ b/dim/src/reactor/handler/mod.rs
@@ -1,23 +1,36 @@
+mod error;
+
 use super::types::EventType;
 use super::types::Table;
 use super::Event;
 use super::Reactor;
 use crate::core::EventTx;
 
+use database::asset::Asset;
+use database::library::Library;
+use database::library::MediaType;
+use database::media::Media;
+use database::rw_pool::SqlitePool;
+
 use events::Message;
 use events::PushEventType;
 
 use async_trait::async_trait;
+use std::path::PathBuf;
 
-pub type Error = std::convert::Infallible;
+pub type Error = error::Error;
 
 pub struct EventReactor {
+    pool: SqlitePool,
     ws_event_tx: Option<EventTx>,
 }
 
 impl EventReactor {
-    pub fn new() -> Self {
-        Self { ws_event_tx: None }
+    pub fn new(pool: SqlitePool) -> Self {
+        Self {
+            pool,
+            ws_event_tx: None,
+        }
     }
 
     pub fn with_websocket(mut self, event_tx: EventTx) -> Self {
@@ -25,7 +38,7 @@ impl EventReactor {
         self
     }
 
-    pub fn handle_library(&mut self, event: Event) -> Result<(), Error> {
+    async fn handle_library(&mut self, event: Event) -> Result<(), Error> {
         let Some(event_tx) = self.ws_event_tx.as_mut() else {
             return Ok(());
         };
@@ -36,6 +49,100 @@ impl EventReactor {
         let event_type = match event.event_type {
             EventType::Insert => PushEventType::EventNewLibrary,
             EventType::Delete => PushEventType::EventRemoveLibrary,
+            EventType::Update => {
+                // NOTE: Library usually get marked as hidden before being deleted as a UX
+                // optimization. Sometimes library deletes can take a while.
+                let mut tx = self
+                    .pool
+                    .read_ref()
+                    .begin()
+                    .await
+                    .map_err(Error::ReadTransaction)?;
+
+                let Library { hidden, .. } = Library::get_one(&mut tx, event.id)
+                    .await
+                    .map_err(Error::LibraryQuery)?;
+
+                if !hidden {
+                    return Ok(());
+                }
+
+                PushEventType::EventRemoveLibrary
+            }
+        };
+
+        let event = Message {
+            id: event.id,
+            event_type,
+        };
+
+        event_tx
+            .send(serde_json::to_string(&event).expect("Serializing event should never fail"))
+            .map_err(Error::EventDispatch)?;
+
+        Ok(())
+    }
+
+    async fn handle_assets(&mut self, event: Event) -> Result<(), Error> {
+        assert_eq!(event.table, Table::Assets);
+
+        if !matches!(event.event_type, EventType::Insert) {
+            return Ok(());
+        }
+
+        let mut tx = self
+            .pool
+            .read_ref()
+            .begin()
+            .await
+            .map_err(Error::ReadTransaction)?;
+
+        let Asset {
+            remote_url,
+            local_path,
+            ..
+        } = Asset::get_by_id(&mut tx, event.id)
+            .await
+            .map_err(Error::AssetQuery)?;
+
+        if let Some(remote_url) = remote_url {
+            let path = PathBuf::from(local_path);
+
+            if let Some(local_file) = path.iter().last().map(|x| x.to_string_lossy().to_string()) {
+                crate::fetcher::insert_into_queue(remote_url, local_file, false).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_media(&mut self, event: Event) -> Result<(), Error> {
+        let Some(event_tx) = self.ws_event_tx.as_mut() else {
+            return Ok(());
+        };
+
+        assert_eq!(event.table, Table::Media);
+
+        let mut tx = self
+            .pool
+            .read_ref()
+            .begin()
+            .await
+            .map_err(Error::ReadTransaction)?;
+
+        let event_type = match event.event_type {
+            EventType::Insert => {
+                let (library_id, media_type) = Media::get_compact(&mut tx, event.id)
+                    .await
+                    .map_err(Error::MediaQuery)?;
+
+                if !matches!(media_type, MediaType::Movie | MediaType::Tv) {
+                    return Ok(());
+                }
+
+                PushEventType::EventNewCard { lib_id: library_id }
+            }
+            EventType::Delete => PushEventType::EventRemoveCard,
             _ => return Ok(()),
         };
 
@@ -46,7 +153,7 @@ impl EventReactor {
 
         event_tx
             .send(serde_json::to_string(&event).expect("Serializing event should never fail"))
-            .unwrap();
+            .map_err(Error::EventDispatch)?;
 
         Ok(())
     }
@@ -58,8 +165,9 @@ impl Reactor for EventReactor {
 
     async fn react(&mut self, event: Event) -> Result<(), Self::Error> {
         match event.table {
-            Table::Library => self.handle_library(event),
-            _ => return Ok(()),
+            Table::Library => self.handle_library(event).await,
+            Table::Media => self.handle_media(event).await,
+            Table::Assets => self.handle_assets(event).await,
         }
     }
 }

--- a/dim/src/reactor/types.rs
+++ b/dim/src/reactor/types.rs
@@ -1,0 +1,44 @@
+use rusqlite::hooks::Action;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Table {
+    Library,
+    Media,
+}
+
+impl TryFrom<&str> for Table {
+    type Error = ();
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "library" => Ok(Self::Library),
+            "media" => Ok(Self::Media),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum EventType {
+    Insert,
+    Update,
+    Delete,
+}
+
+impl From<Action> for EventType {
+    fn from(action: Action) -> EventType {
+        match action {
+            Action::SQLITE_INSERT => EventType::Insert,
+            Action::SQLITE_UPDATE => EventType::Update,
+            Action::SQLITE_DELETE => EventType::Delete,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Event {
+    pub id: i64,
+    pub event_type: EventType,
+    pub table: Table,
+}

--- a/dim/src/reactor/types.rs
+++ b/dim/src/reactor/types.rs
@@ -4,6 +4,7 @@ use rusqlite::hooks::Action;
 pub enum Table {
     Library,
     Media,
+    Assets,
 }
 
 impl TryFrom<&str> for Table {
@@ -12,7 +13,8 @@ impl TryFrom<&str> for Table {
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
             "library" => Ok(Self::Library),
-            "media" => Ok(Self::Media),
+            "_tblmedia" => Ok(Self::Media),
+            "assets" => Ok(Self::Assets),
             _ => Err(()),
         }
     }

--- a/dim/src/routes/statik.rs
+++ b/dim/src/routes/statik.rs
@@ -166,7 +166,7 @@ pub async fn get_image(
     // return 200 OK.
     if !Path::new(&file_path).exists() {
         if let Ok(x) = asset::Asset::get_url_by_file(&mut tx, &url_path).await {
-            insert_into_queue(x, path.as_str().into(), 5).await;
+            insert_into_queue(x, path.as_str().into(), true).await;
         }
 
         return Err(errors::DimError::NotFoundError);

--- a/dim/src/scanner/mod.rs
+++ b/dim/src/scanner/mod.rs
@@ -224,15 +224,14 @@ pub async fn start_custom(
 
     let now = Instant::now();
     let workunits = insert_mediafiles(conn, library_id, dirs).await?;
+    let workunits_size = workunits.len();
 
     info!(
         library_id,
-        units = workunits.len(),
+        units = workunits_size,
         elapsed_ms = now.elapsed().as_millis(),
         "Walked and inserted mediafiles."
     );
-
-    let now = Instant::now();
 
     // NOTE: itertools::GroupBy is used across an await point and thus must also be Sync. This
     // breaks some of our higher-level logic where we spawn this task. Thus we collect it before
@@ -263,6 +262,7 @@ pub async fn start_custom(
 
     info!(
         library_id,
+        units = workunits_size,
         elapsed_ms = now.elapsed().as_millis(),
         "Finished scanning library."
     );


### PR DESCRIPTION
This PR extends #447.

This PR implements a CDC pipeline for sqlite3 allowing us to decouple event sending from the scanners to simplify a lot of the logic. At the moment the CDC pipeline handles the sending of `LibraryCreated`, `LibraryDeleted`, `MediaCreated` and `MediaDeleted` websocket events. In addition it listens to changes on the `assets` table and when an asset is inserted, it is forwarded to the asset fetcher so that the assets get cached locally.

In the future this pipeline could be used for sending more granular events which contain changes to matched media objects, such as description changed, title changed, poster changed, etc. Or it could simply be reused to signal to clients that new data is available and that they should refetch.

This PR doesnt implement `MediafileMatched` events.