### PR TITLE
scss Overflow TItle UX improvements

### DIFF
--- a/ui/src/Components/Card/HoverCard.scss
+++ b/ui/src/Components/Card/HoverCard.scss
@@ -60,6 +60,7 @@
     }
 
     h2 {
+      overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       font-size: 1.4em;

--- a/ui/src/Components/Card/Index.scss
+++ b/ui/src/Components/Card/Index.scss
@@ -80,6 +80,8 @@
     }
 
     p {
+      overflow: hidden;
+      text-overflow: ellipsis;
       text-align: center;
       color: var(--secondaryTextColor);
       padding: 0 2px;

--- a/ui/src/Pages/Media/MetaContent.scss
+++ b/ui/src/Pages/Media/MetaContent.scss
@@ -48,6 +48,8 @@
   }
 
   .title {
+    overflow: hidden;
+    text-overflow: ellipsis;
     display: flex;
     justify-content: space-between;
     max-width: 60ch;


### PR DESCRIPTION
The titles in the dashboard did not allowed long titles to be shortened and hidden, this meant that if a title was to be long in size it went past the width of the card and unto the next card on the right.

In this PR I've fixed this problem and now it allows the titles to be hidden and to shows an ellipses at the end of the width of the card so that it look aesthetically pleasing.