### PR TITLE
Fixing the padding on the menu setting on the Video Player

### DIFF
--- a/ui/src/Modals/NewLibrary/Index.jsx
+++ b/ui/src/Modals/NewLibrary/Index.jsx
@@ -19,8 +19,9 @@ function NewLibraryModal(props) {
   const [current, setCurrent] = useState("");
   const [name, setName] = useState("");
   const [nameErr, setNameErr] = useState("");
-  const [mediaType, setMediaType] = useState("movie");
+  const [mediaType, setMediaType] = useState("");
   const [selectedFolders, setSelectedFolders] = useState([]);
+  const [placeHolderName, setPlaceHolderName] = useState("Untitled");
 
   // prevent scrolling behind Modal
   useEffect(() => {
@@ -30,10 +31,11 @@ function NewLibraryModal(props) {
   }, [visible]);
 
   const clear = useCallback(() => {
+    setPlaceHolderName("Untitled");
     setName("");
     setCurrent("");
     setSelectedFolders([]);
-    setMediaType("movie");
+    setMediaType("");
   }, []);
 
   const close = useCallback(() => {
@@ -89,6 +91,15 @@ function NewLibraryModal(props) {
     }
   }, [close, dispatch, mediaType, name, selectedFolders]);
 
+  useEffect(() => {
+    if (mediaType === "tv") {
+      setPlaceHolderName("Tv/Shows Library");
+    }
+    if (mediaType === "movie") {
+      setPlaceHolderName("Movie Library");
+    }
+  }, [mediaType, setMediaType]);
+
   return (
     <div className="modalBoxContainer">
       {cloneElement(props.children, { onClick: () => open() })}
@@ -107,7 +118,7 @@ function NewLibraryModal(props) {
           <div className="fields">
             <Field
               name="Name"
-              placeholder="Untitled"
+              placeholder={placeHolderName}
               data={[name, setName]}
               error={[nameErr, setNameErr]}
             />


### PR DESCRIPTION
Before the PR was made there was a problem with the padding on the settings menus on the Video Player, the positioning of the menus was not appealing to users and the gaps between the menu and the overlay was too big.

After the PR:

- The padding on the menus has been fixed.
- The gaps are also fixed making it look more appealing to users