### PR TITLE
chore(docker): :bug: docker image fails to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:bullseye AS web
+FROM node:18-bullseye AS web
 WORKDIR /ui
 COPY ui/package*.json ./
 RUN yarn install


### PR DESCRIPTION
The docker build action would fail with the following error:
```
#17 49.07 gyp verb download contents checksum {"node-v19.8.1-headers.tar.gz":"5f43254cf730dbf5747ea7f33d3e007eeb1e207c9bbd081d0fb3c121e4c07ac7"}
#17 49.07 gyp verb validating download checksum for node-v19.8.1-headers.tar.gz (5f43254cf730dbf5747ea7f33d3e007eeb1e207c9bbd081d0fb3c121e4c07ac7 == 5f43254cf730dbf5747ea7f33d3e007eeb1e207c9bbd081d0fb3c121e4c07ac7)
#17 49.07 gyp verb get node dir target node version installed: 19.8.1
#17 49.07 gyp verb build dir attempting to create "build" dir: /ui/node_modules/node-sass/build
#17 49.07 gyp verb build dir "build" dir needed to be created? /ui/node_modules/node-sass/build
#17 49.07 gyp verb build/config.gypi creating config file
#17 49.07 gyp ERR! UNCAUGHT EXCEPTION 
#17 49.07 gyp ERR! stack TypeError: Cannot assign to read only property 'cflags' of object '#<Object>'
#17 49.07 gyp ERR! stack     at createConfigFile (/ui/node_modules/node-gyp/lib/configure.js:117:21)
#17 49.07 gyp ERR! stack     at /ui/node_modules/node-gyp/lib/configure.js:84:9
#17 49.07 gyp ERR! stack     at FSReqCallback.oncomplete (node:fs:185:23)
#17 49.07 gyp ERR! System Linux 5.15.0-1034-azure
#17 49.07 gyp ERR! command "/usr/local/bin/node" "/ui/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
#17 49.07 gyp ERR! cwd /ui/node_modules/node-sass
#17 49.07 gyp ERR! node -v v19.8.1
#17 49.07 gyp ERR! node-gyp -v v7.1.2
#17 49.07 gyp ERR! Node-gyp failed to build your package.
#17 49.07 gyp ERR! Try to update npm and/or node-gyp and if it does not help file an issue with the package author.
#17 49.07 Build failed with error code: 7
#17 ERROR: process "/bin/sh -c yarn install" did not complete successfully: exit code: 1
```

Using node's latest LTS version (18.x) the docker image builds correctly.