### PR TITLE
fix(dim-web): route react routes properly

### DIFF
--- a/dim/src/core.rs
+++ b/dim/src/core.rs
@@ -290,11 +290,14 @@ pub async fn warp_core(
                     .or(invites::filters::delete_token(conn.clone()))
             }),
         )
+        .route_service("/", warp::service(routes::statik::filters::react_routes()))
+        .route_service(
+            "/*path",
+            warp::service(routes::statik::filters::react_routes()),
+        )
         .route_service(
             "/static/*path",
-            warp::service(
-                routes::statik::filters::dist_static().or(routes::statik::filters::react_routes()),
-            ),
+            warp::service(routes::statik::filters::dist_static()),
         )
         .route("/ws", dim_web::axum::routing::get(ws_handler))
         .with_state(AppState {


### PR DESCRIPTION
Closes #543

In the previous web code `warp::get().map(super::react_routes)` would be triggered for any `/` & `/%whatever%` route, I missed this detail in the initial port to axum's router. now the new routing logic will behave likewise.

