### PR TITLE
CI: fix docker nodejs ui build

### DIFF
--- a/.github/workflows/docker-image-rust-target-multi.yml
+++ b/.github/workflows/docker-image-rust-target-multi.yml
@@ -22,7 +22,11 @@ jobs:
             cache: 'yarn'
       - run: npm install -g yarn
       - run: yarn -d --cwd ui/ install
+        env:
+            NODE_OPTIONS: --openssl-legacy-provider
       - run: yarn -d --cwd ui/ build
+        env:
+            NODE_OPTIONS: --openssl-legacy-provider
       - name: upload ui artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Add: `NODE_OPTIONS=--openssl-legacy-provider` due usage of node 18