### PR TITLE
Migrate whoami route to Axum router with authentication middleware

### DIFF
--- a/dim-database/src/user.rs
+++ b/dim-database/src/user.rs
@@ -178,7 +178,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct User {
     pub id: UserID,
     pub username: String,

--- a/dim/src/errors.rs
+++ b/dim/src/errors.rs
@@ -1,4 +1,5 @@
 use dim_database::DatabaseError;
+use dim_web::axum::response::{IntoResponse, Response};
 use displaydoc::Display;
 use thiserror::Error;
 
@@ -134,6 +135,41 @@ impl warp::Reply for DimError {
             .header("ContentType", "application/json")
             .body(serde_json::to_string(&resp).unwrap().into())
             .unwrap()
+    }
+}
+
+impl IntoResponse for DimError {
+    fn into_response(self) -> Response {
+        let status = match self {
+            Self::LibraryNotFound
+            | Self::NoneError
+            | Self::NotFoundError
+            | Self::ExternalSearchError(_) => StatusCode::NOT_FOUND,
+            Self::StreamingError(_)
+            | Self::DatabaseError { .. }
+            | Self::UnknownError
+            | Self::IOError
+            | Self::InternalServerError
+            | Self::UploadFailed
+            | Self::ScannerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Unauthenticated
+            | Self::Unauthorized
+            | Self::InvalidCredentials
+            | Self::CookieError(_)
+            | Self::NoToken
+            | Self::UserNotFound => StatusCode::UNAUTHORIZED,
+            Self::UsernameNotAvailable => StatusCode::BAD_REQUEST,
+            Self::UnsupportedFile | Self::InvalidMediaType | Self::MissingFieldInBody { .. } => {
+                StatusCode::NOT_ACCEPTABLE
+            }
+            Self::MediafileRouteError(ref e) => e.status_code(),
+        };
+
+        let resp = json!({
+            "error": json!(&self)["error"],
+            "messsage": self.to_string(),
+        });
+        (status, serde_json::to_string(&resp).unwrap()).into_response()
     }
 }
 


### PR DESCRIPTION
Continuing the Axum router migration work outlined here: https://github.com/Dusk-Labs/dim/issues/548

This PR migrates the `/api/v1/auth/whoami` route and implements Axum middleware for authentication in `core::with_auth`.
