### PR TITLE
Nightfall with ffmpeg >= v6.0

### DIFF
--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -7,20 +7,18 @@ RUN apt update && \
     apt install -y --no-install-recommends wget unzip tar ca-certificates xz-utils
 
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
-    wget https://github.com/Dusk-Labs/ffmpeg-static/releases/download/ffmpeg-all-0.0.1/ffmpeg && \
-    wget https://github.com/Dusk-Labs/ffmpeg-static/releases/download/ffmpeg-all-0.0.1/ffprobe && \
-    ls -la . && \
-    pwd \
+    wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && \
+    tar --strip-components 1 -xf ffmpeg-release-amd64-static.tar.xz \
     ; fi
     
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
-    wget https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-arm64-static.tar.xz && \
-    tar --strip-components 1 -xf ffmpeg-5.1.1-arm64-static.tar.xz \
+    wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz && \
+    tar --strip-components 1 -xf ffmpeg-release-arm64-static.tar.xz \
     ; fi
     
 RUN if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then \
-    wget https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-armhf-static.tar.xz && \
-    tar --strip-components 1 -xf ffmpeg-5.1.1-armhf-static.tar.xz \
+    wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-armhf-static.tar.xz && \
+    tar --strip-components 1 -xf ffmpeg-release-armhf-static.tar.xz \
     ; fi
     
 RUN chmod +x /static/ffmpeg && chmod +x /static/ffprobe

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,21 +32,11 @@ jobs:
           override: true
           components: cargo
 
-      - name: Download ffmpeg artifact
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: "Dusk-Labs/ffmpeg-static"
-          version: "tags/ffmpeg-all-0.0.1"
-          file: "ffmpeg"
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download ffprobe artifact
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: "Dusk-Labs/ffmpeg-static"
-          version: "tags/ffmpeg-all-0.0.1"
-          file: "ffprobe"
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download static ffmpeg/ffprobe
+        run: |
+          curl -OL https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+          tar --strip-components 1 -xf ffmpeg-release-amd64-static.tar.xz --wildcards '*ffmpeg'
+          tar --strip-components 1 -xf ffmpeg-release-amd64-static.tar.xz --wildcards '*ffprobe'
 
       - name: Create release dir
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,8 @@ RUN apt update && \
     apt install -y --no-install-recommends wget unzip tar ca-certificates xz-utils
 
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
-    wget https://github.com/Dusk-Labs/ffmpeg-static/releases/download/ffmpeg-all-0.0.1/ffmpeg && \
-    wget https://github.com/Dusk-Labs/ffmpeg-static/releases/download/ffmpeg-all-0.0.1/ffprobe && \
-    ls -la . && \
-    pwd \
+    wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz && \
+    tar --strip-components 1 -xf ffmpeg-release-amd64-static.tar.xz \
     ; fi
     
 RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \

--- a/dim-core/Cargo.toml
+++ b/dim-core/Cargo.toml
@@ -15,7 +15,7 @@ embed_ui = []
 
 [dependencies]
 # git dependencies
-nightfall = { git = "https://github.com/Dusk-Labs/nightfall", tag = "0.3.12-rc4", default-features = false, features = [
+nightfall = { git = "https://github.com/Dusk-Labs/nightfall", rev = "08a5d3a2beb6b9217f2551fa44f8410369e34815", default-features = false, features = [
     "cuda",
     "ssa_transmux",
 ] }

--- a/dim-web/Cargo.toml
+++ b/dim-web/Cargo.toml
@@ -10,7 +10,7 @@ dim-utils = { path = "../dim-utils" }
 dim-events = { path = "../dim-events" }
 dim-core = { path = "../dim-core" }
 
-nightfall = { git = "https://github.com/Dusk-Labs/nightfall", tag = "0.3.12-rc4", default-features = false, features = [
+nightfall = { git = "https://github.com/Dusk-Labs/nightfall", rev = "08a5d3a2beb6b9217f2551fa44f8410369e34815", default-features = false, features = [
     "cuda",
     "ssa_transmux",
 ] }

--- a/dim/Cargo.toml
+++ b/dim/Cargo.toml
@@ -15,7 +15,7 @@ xtra = { version = "0.5.1", features = ["tokio", "with-tokio-1"] }
 fdlimit = "0.2.1"
 
 # git dependencies
-nightfall = { git = "https://github.com/Dusk-Labs/nightfall", tag = "0.3.12-rc4", default-features = false, features = [
+nightfall = { git = "https://github.com/Dusk-Labs/nightfall", rev = "08a5d3a2beb6b9217f2551fa44f8410369e34815", default-features = false, features = [
     "cuda",
     "ssa_transmux",
 ] }


### PR DESCRIPTION
This changes the default static ffmpeg release to v6.1 currently to complement changes in https://github.com/Dusk-Labs/nightfall/pull/15

This PR is in a draft until:
- it is known whether the nightfall dependency will receive an updated tag (so the temporary revision SHA in use can be replaced with a tag)
- the implications of no longer using Dusk-Labs/ffmpeg-static for the build are better understood
    - I attempted to update Dusk-Labs/ffmpeg-static myself, but it seems to need more attention than some version bumps in the build script