### PR TITLE
Season order fix and episode React keys are now unique

### DIFF
--- a/ui/src/Pages/Media/Episodes.jsx
+++ b/ui/src/Pages/Media/Episodes.jsx
@@ -27,9 +27,9 @@ function MediaEpisodes(props) {
       {episodes.length === 0 && <p className="desc">Empty</p>}
       {episodes.length > 0 && (
         <div className="episodes" ref={episodesDiv}>
-          {episodes.map((ep, i) => (
+          {episodes.map((ep) => (
             <SelectMediaFile
-              key={i}
+              key={ep.id}
               title={`Episode ${ep.episode}`}
               mediaID={ep.id}
             >

--- a/ui/src/Pages/Media/Seasons.jsx
+++ b/ui/src/Pages/Media/Seasons.jsx
@@ -15,7 +15,10 @@ function MediaSeasons(props) {
   const [season, setSeason] = useState();
   const [prevID, setPrevID] = useState();
 
-  const { data: seasons } = useGetMediaSeasonsQuery(id);
+  let { data: seasons } = useGetMediaSeasonsQuery(id);
+  seasons = seasons?.slice().sort((a, b) => {
+    return a.season_number - b.season_number;
+  });
 
   useEffect(() => {
     if (!seasons) return;


### PR DESCRIPTION
Resolves https://github.com/Dusk-Labs/dim/issues/488

It appears that we have an implicit assumption that data from the API will already be ordered. I opted to fix this client-side, but if it is preferable to always handle this server-side I can make those adjustments.