### PR TITLE
Fix WebSocket communication

### DIFF
--- a/dim-web/src/lib.rs
+++ b/dim-web/src/lib.rs
@@ -330,7 +330,6 @@ pub async fn start_webserver(
 
     let event_repeater = routes::websocket::event_repeater(
         tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx),
-        1024,
     );
 
     let socket_tx = event_repeater.sender();

--- a/dim-web/src/lib.rs
+++ b/dim-web/src/lib.rs
@@ -330,6 +330,7 @@ pub async fn start_webserver(
 
     let event_repeater = routes::websocket::event_repeater(
         tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx),
+        1024,
     );
 
     let socket_tx = event_repeater.sender();


### PR DESCRIPTION
Resolves https://github.com/Dusk-Labs/dim/issues/590

I still don't fully understand why this was broken, but it seems that the `ctrl_event_processor` function couldn't match received events from a `tokio::sync::mpsc::Receiver` and only matched against an `tokio::sync::mpsc::UnboundedReceiver`.
