### PR TITLE
fix: enforce core application security boundaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
           chmod +x release/utils/ffprobe
 
       - name: Create Cargo target directory
-        run: mkdir -p target
+        run: mkdir -p target dim-database/target
 
       - name: Test Dim
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_TARGET_DIR: target
   DATABASE_URL: "sqlite://./dim_dev.db"
 
 jobs:
@@ -56,11 +57,11 @@ jobs:
           chmod +x release/utils/ffmpeg
           chmod +x release/utils/ffprobe
 
-      # - name: Test Dim
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: test
-      #     args: --tests
+      - name: Test Dim
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --locked
 
       - name: Build Dim
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_TARGET_DIR: target
+  CARGO_TARGET_DIR: ${{ github.workspace }}/target
   DATABASE_URL: "sqlite://./dim_dev.db"
 
 jobs:
@@ -58,7 +58,7 @@ jobs:
           chmod +x release/utils/ffprobe
 
       - name: Create Cargo target directory
-        run: mkdir -p target dim-database/target
+        run: mkdir -p target
 
       - name: Test Dim
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,9 @@ jobs:
           chmod +x release/utils/ffmpeg
           chmod +x release/utils/ffprobe
 
+      - name: Create Cargo target directory
+        run: mkdir -p target
+
       - name: Test Dim
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid 1.18.1",
+ "xtra",
 ]
 
 [[package]]

--- a/dim-core/src/fetcher.rs
+++ b/dim-core/src/fetcher.rs
@@ -12,7 +12,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::io::copy;
 use std::io::Cursor;
-use std::path::PathBuf;
 
 use once_cell::sync::OnceCell;
 
@@ -52,9 +51,17 @@ async fn process_queue(mut rx: UnboundedReceiver<(String, String)>) {
 
         match reqwest::get(url.as_str()).await {
             Ok(resp) => {
-                let meta_path = METADATA_PATH.get().unwrap();
-                let mut out_path = PathBuf::from(meta_path);
-                out_path.push(outfile);
+                let Some(meta_path) = METADATA_PATH.get() else {
+                    error!(url = &url, "Metadata path is not initialized.");
+                    continue;
+                };
+                let out_path = match crate::utils::safe_metadata_path(meta_path, &outfile) {
+                    Ok(path) => path,
+                    Err(e) => {
+                        error!(error = ?e, url = &url, outfile = &outfile, "Rejected unsafe metadata path.");
+                        continue;
+                    }
+                };
 
                 debug!("Caching {} -> {:?}", url, out_path);
 

--- a/dim-core/src/utils.rs
+++ b/dim-core/src/utils.rs
@@ -1,2 +1,104 @@
 pub use dim_utils::json;
 pub use dim_utils::*;
+
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+pub fn safe_relative_path(path: impl AsRef<Path>) -> io::Result<PathBuf> {
+    if path.as_ref().as_os_str().to_string_lossy().contains('\\') {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "metadata path contains a platform-specific separator",
+        ));
+    }
+
+    let mut relative = PathBuf::new();
+
+    for component in path.as_ref().components() {
+        match component {
+            Component::Normal(component) => relative.push(component),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "path must remain relative to the metadata directory",
+                ));
+            }
+        }
+    }
+
+    if relative.as_os_str().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "metadata path must not be empty",
+        ));
+    }
+
+    Ok(relative)
+}
+
+pub fn safe_metadata_path(
+    root: impl AsRef<Path>,
+    relative: impl AsRef<Path>,
+) -> io::Result<PathBuf> {
+    let relative = safe_relative_path(relative)?;
+    let root = std::fs::canonicalize(root)?;
+    let target = root.join(relative);
+
+    let mut existing = target.as_path();
+    while !existing.exists() {
+        existing = existing.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "metadata path has no existing parent",
+            )
+        })?;
+    }
+
+    if !std::fs::canonicalize(existing)?.starts_with(&root) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "metadata path escapes the metadata directory",
+        ));
+    }
+
+    Ok(target)
+}
+
+#[cfg(test)]
+mod path_tests {
+    use super::safe_relative_path;
+
+    #[test]
+    fn accepts_nested_relative_paths() {
+        assert_eq!(
+            safe_relative_path("posters/movie.jpg").unwrap(),
+            std::path::PathBuf::from("posters/movie.jpg")
+        );
+    }
+
+    #[test]
+    fn rejects_escaping_paths() {
+        assert!(safe_relative_path("../secret").is_err());
+        assert!(safe_relative_path("/etc/passwd").is_err());
+        assert!(safe_relative_path(r"C:\Windows\system.ini").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinks_that_escape_the_metadata_directory() {
+        use super::safe_metadata_path;
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!("dim-safe-path-{}", uuid::Uuid::new_v4()));
+        let metadata = root.join("metadata");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&metadata).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, metadata.join("escape")).unwrap();
+
+        assert!(safe_metadata_path(&metadata, "escape/file.jpg").is_err());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/dim-web/Cargo.toml
+++ b/dim-web/Cargo.toml
@@ -54,3 +54,6 @@ tower = { version = "0.4.13", features = ["tokio", "util"] }
 dim-extern-api = { version = "0.4.0-dev", path = "../dim-extern-api" }
 tokio-stream = { version = "0.1.14", features = ["full"] }
 tower-http = { version = "0.4.4", features = ["full"] }
+
+[dev-dependencies]
+xtra = { version = "0.5.1", features = ["tokio", "with-tokio-1"] }

--- a/dim-web/src/lib.rs
+++ b/dim-web/src/lib.rs
@@ -35,6 +35,24 @@ pub struct AppState {
     stream_tracking: StreamTracking,
 }
 
+impl AppState {
+    pub fn new(
+        conn: DbConnection,
+        socket_tx: routes::websocket::EventSocketTx,
+        event_tx: EventTx,
+        state: StateManager,
+        stream_tracking: StreamTracking,
+    ) -> Self {
+        Self {
+            conn,
+            socket_tx,
+            event_tx,
+            state,
+            stream_tracking,
+        }
+    }
+}
+
 fn library_routes(_app: AppState) -> Router<AppState> {
     Router::new()
         .route(
@@ -158,73 +176,38 @@ fn settings_routes(AppState { .. }: AppState) -> Router<AppState> {
     Router::new()
         .route(
             "/api/v1/user/settings",
-            get(|| async { "User settings - needs actual implementation" }),
+            get(routes::settings::get_user_settings),
         )
         .route(
             "/api/v1/user/settings",
-            post(|| async { "User settings post - needs actual implementation" }),
+            post(routes::settings::post_user_settings),
         )
 }
 
-pub async fn start_webserver(
-    address: SocketAddr,
-    event_tx: EventTx,
-    stream_manager: StateManager,
-    event_rx: UnboundedReceiver<String>,
-    shutdown_fut: impl Future<Output = ()> + Send + 'static,
-) {
-    let state = stream_manager;
-    let stream_tracking = StreamTracking::default();
-    let conn = dim_database::get_conn()
-        .await
-        .expect("Failed to grab a handle to the connection pool.");
+async fn ws_handler(
+    ws: axum::extract::WebSocketUpgrade,
+    ConnectInfo(remote_address): ConnectInfo<SocketAddr>,
+    State(AppState {
+        conn, socket_tx, ..
+    }): State<AppState>,
+) -> Response {
+    ws.on_upgrade(move |websocket| async move {
+        let (ws_tx, ws_rx) = websocket.split();
 
-    let event_repeater = routes::websocket::event_repeater(
-        tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx),
-        1024,
-    );
+        routes::websocket::handle_websocket_session(
+            ws_tx.sink_err_into::<routes::websocket::WsMessageError>(),
+            ws_rx.filter_map(|m| async move { m.ok() }),
+            Some(remote_address),
+            conn,
+            socket_tx,
+        )
+        .await;
+    })
+}
 
-    let socket_tx = event_repeater.sender();
-
-    tokio::spawn(event_repeater.into_future());
-
-    async fn ws_handler(
-        ws: axum::extract::WebSocketUpgrade,
-        ConnectInfo(remote_address): ConnectInfo<SocketAddr>,
-        State(AppState {
-            conn, socket_tx, ..
-        }): State<AppState>,
-    ) -> Response {
-        ws.on_upgrade(move |websocket| async move {
-            let (ws_tx, ws_rx) = websocket.split();
-
-            routes::websocket::handle_websocket_session(
-                ws_tx.sink_err_into::<routes::websocket::WsMessageError>(),
-                ws_rx.filter_map(|m| async move { m.ok() }),
-                Some(remote_address),
-                conn,
-                socket_tx,
-            )
-            .await;
-        })
-    }
-
-    let app = AppState {
-        conn: conn.clone(),
-        socket_tx: socket_tx.clone(),
-        event_tx: event_tx.clone(),
-        state,
-        stream_tracking,
-    };
-
-    let router = axum::Router::new()
+pub fn build_router(app: AppState) -> Router {
+    let protected = axum::Router::new()
         .route("/api/v1/auth/whoami", get(routes::auth::whoami))
-        .route_layer(axum::middleware::from_fn_with_state(
-            conn.clone(),
-            verify_cookie_token,
-        ))
-        // --- End of routes authenticated by Axum middleware ---
-        .merge(auth_routes(app.clone()))
         .merge(library_routes(app.clone()))
         .route("/api/v1/dashboard", get(routes::dashboard::dashboard))
         .route("/api/v1/dashboard/banner", get(routes::dashboard::banners))
@@ -233,7 +216,6 @@ pub async fn start_webserver(
             "/api/v1/filebrowser/*path",
             get(routes::filebrowser::get_directory_structure),
         )
-        .route("/images/*path", get(routes::statik::get_image))
         .merge(media_routes(app.clone()))
         .merge(stream_routes(app.clone()))
         .route(
@@ -268,19 +250,47 @@ pub async fn start_webserver(
             "/api/v1/auth/token/:token",
             delete(routes::auth::delete_token),
         )
+        .route_layer(axum::middleware::from_fn_with_state(
+            app.conn.clone(),
+            verify_cookie_token,
+        ));
+
+    axum::Router::new()
+        .merge(auth_routes(app.clone()))
+        .route("/images/*path", get(routes::statik::get_image))
         .route("/", get(routes::statik::react_routes))
         .route("/*path", get(routes::statik::react_routes))
         .route("/static/*path", get(routes::statik::dist_static))
         .route("/ws", get(ws_handler))
+        .merge(protected)
         .with_state(app)
         .layer(tower_http::trace::TraceLayer::new_for_http())
-        .layer({
-            let cors = tower_http::cors::CorsLayer::new()
-                // allow requests from any origin
-                .allow_origin(tower_http::cors::Any);
+}
 
-            cors
-        });
+pub async fn start_webserver(
+    address: SocketAddr,
+    event_tx: EventTx,
+    stream_manager: StateManager,
+    event_rx: UnboundedReceiver<String>,
+    shutdown_fut: impl Future<Output = ()> + Send + 'static,
+) {
+    let state = stream_manager;
+    let stream_tracking = StreamTracking::default();
+    let conn = dim_database::get_conn()
+        .await
+        .expect("Failed to grab a handle to the connection pool.");
+
+    let event_repeater = routes::websocket::event_repeater(
+        tokio_stream::wrappers::UnboundedReceiverStream::new(event_rx),
+        1024,
+    );
+
+    let socket_tx = event_repeater.sender();
+
+    tokio::spawn(event_repeater.into_future());
+
+    let app = AppState::new(conn, socket_tx, event_tx, state, stream_tracking);
+    let router = build_router(app);
 
     tracing::info!(%address, "webserver is listening");
 

--- a/dim-web/src/middleware.rs
+++ b/dim-web/src/middleware.rs
@@ -1,36 +1,64 @@
+use axum::extract::FromRequestParts;
 use axum::extract::State;
+use axum::http::request::Parts;
 use dim_core::errors::DimError;
+use dim_database::user::User;
 use dim_database::DbConnection;
 
 use crate::DimErrorWrapper;
+
+/// Extractor for routes that require the authenticated user to have the owner role.
+pub struct Owner;
+
+#[axum::async_trait]
+impl<S> FromRequestParts<S> for Owner
+where
+    S: Send + Sync,
+{
+    type Rejection = DimErrorWrapper;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let user = parts
+            .extensions
+            .get::<User>()
+            .ok_or(DimErrorWrapper(DimError::Unauthenticated))?;
+
+        if user.has_role("owner") {
+            Ok(Self)
+        } else {
+            Err(DimErrorWrapper(DimError::Unauthorized))
+        }
+    }
+}
 
 pub async fn verify_cookie_token<B>(
     State(conn): State<DbConnection>,
     mut req: axum::http::Request<B>,
     next: axum::middleware::Next<B>,
 ) -> Result<axum::response::Response, DimErrorWrapper> {
-    match req.headers().get(axum::http::header::AUTHORIZATION) {
-        Some(token) => {
-            let mut tx = match conn.read().begin().await {
-                Ok(tx) => tx,
-                Err(_) => {
-                    return Err(DimErrorWrapper(DimError::DatabaseError {
-                        description: String::from("Failed to start transaction"),
-                    }))
-                }
-            };
-            let id = dim_database::user::Login::verify_cookie(token.to_str().unwrap().to_string())
-                .map_err(|e| DimError::CookieError(e))
-                .map_err(|e| DimErrorWrapper(e))?;
+    let token = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .ok_or(DimErrorWrapper(DimError::Unauthenticated))?
+        .to_str()
+        .map_err(|_| DimErrorWrapper(DimError::InvalidCredentials))?;
 
-            let current_user = dim_database::user::User::get_by_id(&mut tx, id)
-                .await
-                .map_err(|_| DimError::UserNotFound)
-                .map_err(|e| DimErrorWrapper(e))?;
-
-            req.extensions_mut().insert(current_user);
-            Ok(next.run(req).await)
-        }
-        None => Err(DimErrorWrapper(DimError::NoToken)),
+    if token.is_empty() {
+        return Err(DimErrorWrapper(DimError::InvalidCredentials));
     }
+
+    let mut tx = conn.read().begin().await.map_err(|_| {
+        DimErrorWrapper(DimError::DatabaseError {
+            description: String::from("Failed to start transaction"),
+        })
+    })?;
+    let id = dim_database::user::Login::verify_cookie(token.to_owned())
+        .map_err(|_| DimErrorWrapper(DimError::InvalidCredentials))?;
+
+    let current_user = dim_database::user::User::get_by_id(&mut tx, id)
+        .await
+        .map_err(|_| DimErrorWrapper(DimError::InvalidCredentials))?;
+
+    req.extensions_mut().insert(current_user);
+    Ok(next.run(req).await)
 }

--- a/dim-web/src/routes/auth.rs
+++ b/dim-web/src/routes/auth.rs
@@ -40,6 +40,8 @@ use http::StatusCode;
 use serde_json::json;
 use thiserror::Error;
 
+use crate::middleware::Owner;
+
 #[derive(Debug, Display, Error)]
 pub enum AuthError {
     /// Not logged in.
@@ -110,48 +112,44 @@ impl IntoResponse for AuthError {
 ///
 /// [`AuthError`]
 pub async fn get_all_invites(
-    Extension(user): Extension<User>,
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
 ) -> Result<axum::response::Response, AuthError> {
     let mut tx = conn.read().begin().await.map_err(DatabaseError::from)?;
-    if user.has_role("owner") {
-        #[derive(serde::Serialize)]
-        struct Row {
-            id: String,
-            created: i64,
-            claimed_by: Option<String>,
-        }
+    #[derive(serde::Serialize)]
+    struct Row {
+        id: String,
+        created: i64,
+        claimed_by: Option<String>,
+    }
 
-        // FIXME: LEFT JOINs cause sqlx::query! to panic, thus we must get tokens in two queries.
-        // TODO: Move these into database.
-        // TODO: We silently drop db errors here, we should probably change this.
-        let mut row = sqlx::query_as!(
-            Row,
-            r#"SELECT invites.id, invites.date_added as created, NULL as "claimed_by: _"
+    // FIXME: LEFT JOINs cause sqlx::query! to panic, thus we must get tokens in two queries.
+    // TODO: Move these into database.
+    // TODO: We silently drop db errors here, we should probably change this.
+    let mut row = sqlx::query_as!(
+        Row,
+        r#"SELECT invites.id, invites.date_added as created, NULL as "claimed_by: _"
                 FROM invites
                 WHERE invites.id NOT IN (SELECT users.claimed_invite FROM users)
                 ORDER BY created ASC"#
+    )
+    .fetch_all(&mut tx)
+    .await
+    .unwrap_or_default();
+
+    row.append(
+        &mut sqlx::query_as!(
+            Row,
+            r#"SELECT invites.id, invites.date_added as created, users.username as "claimed_by: Option<String>"
+            FROM  invites
+            INNER JOIN users ON users.claimed_invite = invites.id"#
         )
         .fetch_all(&mut tx)
         .await
-        .unwrap_or_default();
+        .unwrap_or_default(),
+    );
 
-        row.append(
-            &mut sqlx::query_as!(
-                Row,
-                r#"SELECT invites.id, invites.date_added as created, users.username as "claimed_by: Option<String>"
-            FROM  invites
-            INNER JOIN users ON users.claimed_invite = invites.id"#
-            )
-            .fetch_all(&mut tx)
-            .await
-            .unwrap_or_default(),
-        );
-
-        return Ok(axum::response::Json(json!(&row)).into_response());
-    }
-
-    Err(AuthError::InvalidCredentials)
+    Ok(axum::response::Json(json!(&row)).into_response())
 }
 
 /// # POST `/api/v1/auth/new_invite`
@@ -187,13 +185,9 @@ pub async fn get_all_invites(
 ///
 /// [`AuthError`]
 pub async fn generate_invite(
-    Extension(user): Extension<User>,
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
 ) -> Result<axum::response::Response, AuthError> {
-    if !user.has_role("owner") {
-        return Err(AuthError::InvalidCredentials);
-    }
-
     let mut lock = conn.writer().lock_owned().await;
     let mut tx = dim_database::write_tx(&mut lock)
         .await
@@ -228,14 +222,10 @@ pub async fn generate_invite(
 ///
 /// [`AuthError`]
 pub async fn delete_token(
-    Extension(user): Extension<User>,
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(token): Path<String>,
 ) -> Result<impl IntoResponse, AuthError> {
-    if !user.has_role("owner") {
-        return Err(AuthError::InvalidCredentials);
-    }
-
     let mut lock = conn.writer().lock_owned().await;
     let mut tx = dim_database::write_tx(&mut lock)
         .await
@@ -372,7 +362,10 @@ pub async fn admin_exists(
     State(AppState { conn, .. }): State<AppState>,
 ) -> Result<Response, LoginError> {
     let mut tx = conn.read().begin().await.map_err(DatabaseError::from)?;
-    let exists = dbg!(User::get_all(&mut tx).await.map_err(LoginError::Database)?).is_empty();
+    let exists = User::get_all(&mut tx)
+        .await
+        .map_err(LoginError::Database)?
+        .is_empty();
     let value = json!({
         "exists": !exists
     });

--- a/dim-web/src/routes/filebrowser.rs
+++ b/dim-web/src/routes/filebrowser.rs
@@ -13,6 +13,8 @@ use std::path::PathBuf;
 use displaydoc::Display;
 use thiserror::Error;
 
+use crate::middleware::Owner;
+
 #[derive(Debug, Display, Error)]
 pub enum AuthError {
     /// IO Error.
@@ -64,6 +66,7 @@ pub fn enumerate_directory<T: AsRef<std::path::Path>>(path: T) -> io::Result<Vec
 }
 
 pub async fn get_directory_structure(
+    _owner: Owner,
     path: Option<Path<String>>,
 ) -> Result<axum::response::Response, AuthError> {
     cfg_if::cfg_if! {
@@ -92,7 +95,7 @@ pub async fn get_directory_structure(
     Ok(axum::response::Json(
         &spawn_blocking(|| enumerate_directory(path))
             .await
-            .unwrap()?,
+            .map_err(|_| AuthError::IOError)??,
     )
     .into_response())
 }

--- a/dim-web/src/routes/library.rs
+++ b/dim-web/src/routes/library.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use axum::extract::{Path, Query, State};
 use axum::response::{IntoResponse, Response};
-use axum::Extension;
 use axum::Json;
 
 use dim_core::errors::DimError;
@@ -14,7 +13,6 @@ use dim_database::compact_mediafile::CompactMediafile;
 use dim_database::library::{InsertableLibrary, Library, MediaType};
 use dim_database::media::Media;
 use dim_database::mediafile::MediaFile;
-use dim_database::user::User;
 
 use dim_extern_api::tmdb::TMDBMetadataProvider;
 
@@ -25,6 +23,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::error::DimErrorWrapper;
+use crate::middleware::Owner;
 use crate::AppState;
 
 /// Method maps to `POST /api/v1/library`, it adds a new library to the database, starts a new
@@ -32,17 +31,10 @@ use crate::AppState;
 /// been created. This method can only be accessed by authenticated users. Method returns 200 OK
 ///
 pub async fn library_post(
-    Extension(user): Extension<User>,
+    _owner: Owner,
     State(state): State<AppState>,
     Json(new_library): Json<InsertableLibrary>,
 ) -> Response {
-    if !user.has_role("owner") {
-        return (
-            StatusCode::UNAUTHORIZED,
-            "User account is not allowed to add a library.".to_string(),
-        )
-            .into_response();
-    }
     let mut lock = state.conn.writer().lock_owned().await;
 
     let mut tx = match dim_database::write_tx(&mut lock).await {
@@ -98,13 +90,10 @@ pub async fn library_post(
 
 /// Method mapped to `DELETE /api/v1/library/<id>` deletes the library with the supplied id from the path.
 pub async fn library_delete(
-    Extension(user): Extension<User>,
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<StatusCode, DimErrorWrapper> {
-    if !user.has_role("owner") {
-        return Err(DimErrorWrapper(DimError::Unauthorized));
-    }
     // First we mark the library as scheduled for deletion which will make the library and all its
     // content hidden. This is necessary because huge libraries take a long time to delete.
     {

--- a/dim-web/src/routes/media.rs
+++ b/dim-web/src/routes/media.rs
@@ -48,6 +48,8 @@ use tracing::info;
 use displaydoc::Display;
 use thiserror::Error;
 
+use crate::middleware::Owner;
+
 #[derive(Debug, Display, Error)]
 pub enum Error {
     /// Not Found.
@@ -392,6 +394,7 @@ pub async fn get_mediafile_tree(
 /// * `data` - the info that we changed about the media entry
 /// * `_user` - Auth middleware
 pub async fn update_media_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
     Json(data): Json<UpdateMedia>,
@@ -419,6 +422,7 @@ pub async fn update_media_by_id(
 /// * `id` - id of the media we want to delete
 /// * `_user` - auth middleware
 pub async fn delete_media_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<impl IntoResponse, Error> {
@@ -526,6 +530,7 @@ pub struct RematchMediaParams {
 ///
 /// TODO: Add ability to specify overrides like episode and season ranges.
 pub async fn rematch_media_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
     Json(params): Json<RematchMediaParams>,

--- a/dim-web/src/routes/mediafile.rs
+++ b/dim-web/src/routes/mediafile.rs
@@ -31,6 +31,8 @@ use tracing::info;
 use displaydoc::Display;
 use thiserror::Error;
 
+use crate::middleware::Owner;
+
 #[derive(Debug, Display, Error)]
 pub enum Error {
     /// No mediafiles.
@@ -112,6 +114,7 @@ pub async fn get_mediafile_info(
 /// * `mediafiles` - ids of the orphan mediafiles we want to rematch
 /// * `tmdb_id` - the tmdb id of the proper metadata we want to fetch for the media
 pub async fn rematch_mediafile(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Json(route_args): Json<RouteArgs>,
 ) -> Result<impl IntoResponse, Error> {

--- a/dim-web/src/routes/settings.rs
+++ b/dim-web/src/routes/settings.rs
@@ -11,8 +11,63 @@ use dim_database::user::UpdateableUser;
 use dim_database::user::User;
 use dim_database::user::UserSettings;
 use dim_database::DatabaseError;
+use serde::{Deserialize, Serialize};
 
 use super::auth::AuthError;
+use crate::middleware::Owner;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct HostSettings {
+    pub enable_ssl: bool,
+    pub port: u16,
+    pub priv_key: Option<String>,
+    pub ssl_cert: Option<String>,
+    pub cache_dir: String,
+    pub metadata_dir: String,
+    pub quiet_boot: bool,
+    pub disable_auth: bool,
+    pub verbose: bool,
+    pub enable_hwaccel: bool,
+    pub version: String,
+}
+
+impl From<GlobalSettings> for HostSettings {
+    fn from(settings: GlobalSettings) -> Self {
+        Self {
+            enable_ssl: settings.enable_ssl,
+            port: settings.port,
+            priv_key: settings.priv_key,
+            ssl_cert: settings.ssl_cert,
+            cache_dir: settings.cache_dir,
+            metadata_dir: settings.metadata_dir,
+            quiet_boot: settings.quiet_boot,
+            disable_auth: settings.disable_auth,
+            verbose: settings.verbose,
+            enable_hwaccel: settings.enable_hwaccel,
+            version: settings.version,
+        }
+    }
+}
+
+impl HostSettings {
+    fn into_global_settings(self, secret_key: Option<[u8; 32]>) -> GlobalSettings {
+        GlobalSettings {
+            enable_ssl: self.enable_ssl,
+            port: self.port,
+            priv_key: self.priv_key,
+            ssl_cert: self.ssl_cert,
+            cache_dir: self.cache_dir,
+            metadata_dir: self.metadata_dir,
+            quiet_boot: self.quiet_boot,
+            disable_auth: self.disable_auth,
+            verbose: self.verbose,
+            secret_key,
+            enable_hwaccel: self.enable_hwaccel,
+            version: self.version,
+        }
+    }
+}
 
 pub async fn get_user_settings(
     Extension(user): Extension<User>,
@@ -43,30 +98,27 @@ pub async fn post_user_settings(
     Ok(axum::response::Json(&new_settings).into_response())
 }
 
-fn get_global_settings() -> GlobalSettings {
+fn get_host_settings() -> HostSettings {
     let mut global_settings: GlobalSettings = settings::get_global_settings();
     let git_tag = String::from(env!("GIT_TAG")).to_owned();
     let mut git_sha = String::from(env!("GIT_SHA_256")).to_owned();
     git_sha.truncate(8);
     let version = git_tag + " " + git_sha.as_str();
     global_settings.version = version;
-    global_settings
+    global_settings.into()
 }
 
-// TODO: Hide secret key.
-pub async fn http_get_global_settings() -> Result<Response, AuthError> {
-    Ok(axum::response::Json(&get_global_settings()).into_response())
+pub async fn http_get_global_settings(_owner: Owner) -> Result<Response, AuthError> {
+    Ok(axum::response::Json(&get_host_settings()).into_response())
 }
 
-// TODO: Disallow setting secret key over http.
 pub async fn http_set_global_settings(
-    Extension(user): Extension<User>,
-    Json(new_settings): Json<GlobalSettings>,
+    _owner: Owner,
+    Json(new_settings): Json<HostSettings>,
 ) -> Result<Response, AuthError> {
-    if user.has_role("owner") {
-        set_global_settings(new_settings).unwrap();
-        return Ok(Json(&get_global_settings()).into_response());
-    }
+    let secret_key = settings::get_global_settings().secret_key;
+    set_global_settings(new_settings.into_global_settings(secret_key))
+        .map_err(|error| AuthError::BadRequest(error.to_string()))?;
 
-    Err(AuthError::InvalidCredentials)
+    Ok(Json(&get_host_settings()).into_response())
 }

--- a/dim-web/src/routes/statik.rs
+++ b/dim-web/src/routes/statik.rs
@@ -16,7 +16,6 @@ use dim_database::asset;
 use http::StatusCode;
 use rust_embed::RustEmbed;
 
-use std::path;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -67,12 +66,16 @@ pub async fn get_image(
     Path(path): Path<String>,
     Query(params): Query<ImageParams>,
 ) -> Result<impl IntoResponse, DimErrorWrapper> {
-    let meta_path = dim_core::core::METADATA_PATH.get().unwrap();
-    let mut file_path = PathBuf::from(&meta_path);
-    file_path.push(path.as_str());
+    let meta_path = dim_core::core::METADATA_PATH
+        .get()
+        .ok_or(dim_core::errors::DimError::InternalServerError)?;
+    let relative_path = dim_core::utils::safe_relative_path(path.as_str())
+        .map_err(|_| dim_core::errors::DimError::NotFoundError)?;
+    let file_path = dim_core::utils::safe_metadata_path(meta_path, &relative_path)
+        .map_err(|_| dim_core::errors::DimError::NotFoundError)?;
 
     let mut url_path = PathBuf::from("images/");
-    url_path.push(path.as_str());
+    url_path.push(&relative_path);
 
     /*
     let image = if let (Some(w), Some(h)) = (resize_w, resize_h) {
@@ -85,9 +88,9 @@ pub async fn get_image(
     let mut tx = conn.read().begin().await?;
     // FIXME (val): return not yet available error here as a hint that in the future this URL will
     // return 200 OK.
-    if !path::Path::new(&file_path).exists() {
+    if !file_path.exists() {
         if let Ok(x) = asset::Asset::get_url_by_file(&mut tx, &url_path).await {
-            insert_into_queue(x, path.as_str().into(), true).await;
+            insert_into_queue(x, relative_path.to_string_lossy().into_owned(), true).await;
         }
 
         return Err(dim_core::errors::DimError::NotFoundError.into());

--- a/dim-web/src/routes/tv.rs
+++ b/dim-web/src/routes/tv.rs
@@ -13,6 +13,7 @@ use http::StatusCode;
 use serde_json::json;
 
 use super::auth::AuthError;
+use crate::middleware::Owner;
 
 /// Method mapped to `GET /api/v1/tv/<id>/season` returns all seasons for TV Show mapped to the id
 /// passed in.
@@ -49,6 +50,7 @@ pub async fn get_season_by_id(
 /// This route additionally requires you to pass in a json object by the format of
 /// `dim_database::season::UpdateSeason`.
 pub async fn patch_season_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
     Json(season): Json<UpdateSeason>,
@@ -99,6 +101,7 @@ pub async fn get_season_episodes(
 /// # Arguments
 /// * `id` - id of the season.
 pub async fn delete_season_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<impl IntoResponse, AuthError> {
@@ -122,6 +125,7 @@ pub async fn delete_season_by_id(
 /// This route additionally requires you to pass in a json object by the format of
 /// `dim_database::episode::UpdateEpisode`.
 pub async fn patch_episode_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
     Json(episode): Json<UpdateEpisode>,
@@ -142,6 +146,7 @@ pub async fn patch_episode_by_id(
 /// # Arguments
 /// * `id` - id an episode to delete
 pub async fn delete_episode_by_id(
+    _owner: Owner,
     State(AppState { conn, .. }): State<AppState>,
     Path(id): Path<i64>,
 ) -> Result<impl IntoResponse, AuthError> {

--- a/dim-web/src/routes/websocket.rs
+++ b/dim-web/src/routes/websocket.rs
@@ -129,8 +129,9 @@ pub async fn handle_websocket_session(
     };
 
     tokio::pin!(stream);
+    let mut sink: Pin<Box<dyn Sink<WsMessage, Error = WsMessageError> + Send>> = Box::pin(sink);
 
-    'auth_loop: while let Some(message) = stream.next().await {
+    while let Some(message) = stream.next().await {
         if let WsMessage::Text(st) = message {
             if let Ok(ClientActions::Authenticate { token }) = serde_json::from_str(&st) {
                 if let Ok(token_data) = dim_database::user::Login::verify_cookie(token) {
@@ -141,7 +142,7 @@ pub async fn handle_websocket_session(
                             let _ = socket_tx
                                 .send(CtrlEvent::Track {
                                     addr,
-                                    sink: Box::pin(sink),
+                                    sink,
                                     auth: Box::new(u),
                                 })
                                 .await;
@@ -157,23 +158,21 @@ pub async fn handle_websocket_session(
                                 })
                                 .await;
 
-                            break 'auth_loop;
+                            break;
                         }
                     }
                 }
             }
-
-            let _ = socket_tx
-                .send(CtrlEvent::SendTo {
-                    addr,
-                    message: dim_events::Message {
-                        id: -1,
-                        event_type: dim_events::PushEventType::EventAuthErr,
-                    }
-                    .to_string(),
-                })
-                .await;
         }
+
+        let message = dim_events::Message {
+            id: -1,
+            event_type: dim_events::PushEventType::EventAuthErr,
+        }
+        .to_string();
+        let _ = sink.send(WsMessage::Text(message)).await;
+        let _ = sink.close().await;
+        return;
     }
 
     loop {
@@ -272,4 +271,47 @@ where
     };
 
     EventRepeater::new(stream_forward, ctrl_event_processor_fut, tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{SinkExt, StreamExt};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[tokio::test]
+    async fn invalid_authentication_closes_without_tracking_the_socket() {
+        let conn = dim_database::get_conn_memory().await.unwrap();
+        let (outgoing, mut outgoing_rx) = futures::channel::mpsc::unbounded();
+        let sink = outgoing.sink_map_err(|_| WsMessageError);
+        let stream = futures::stream::iter([WsMessage::Text("not-json".to_owned())]);
+        let (socket_tx, mut socket_rx) = mpsc::channel(4);
+
+        handle_websocket_session(
+            sink,
+            stream,
+            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000)),
+            conn,
+            socket_tx,
+        )
+        .await;
+
+        let message = outgoing_rx.next().await.unwrap();
+        let WsMessage::Text(body) = message else {
+            panic!("expected an authentication error message");
+        };
+        assert_eq!(
+            body,
+            dim_events::Message {
+                id: -1,
+                event_type: dim_events::PushEventType::EventAuthErr,
+            }
+            .to_string()
+        );
+        assert!(outgoing_rx.next().await.is_none());
+        assert!(matches!(
+            socket_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected)
+        ));
+    }
 }

--- a/dim-web/tests/security_boundary.rs
+++ b/dim-web/tests/security_boundary.rs
@@ -1,0 +1,298 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use axum::body::Body;
+use axum::http::header::{AUTHORIZATION, CONTENT_TYPE, ORIGIN};
+use axum::http::{HeaderValue, Method, Request, StatusCode};
+use dim_core::stream_tracking::StreamTracking;
+use dim_database::user::{InsertableUser, Roles, UserSettings};
+use dim_web::routes::websocket::CtrlEvent;
+use dim_web::{build_router, AppState};
+use hyper::body::to_bytes;
+use tower::ServiceExt;
+use xtra::spawn::Tokio;
+
+struct TestApp {
+    router: axum::Router,
+    owner_token: String,
+    user_token: String,
+    root: PathBuf,
+}
+
+async fn insert_user(
+    conn: &dim_database::DbConnection,
+    username: &str,
+    role: &str,
+) -> dim_database::user::User {
+    let mut lock = conn.writer().lock_owned().await;
+    let mut tx = dim_database::write_tx(&mut lock).await.unwrap();
+    let invite = dim_database::user::Login::new_invite(&mut tx)
+        .await
+        .unwrap();
+    let user = InsertableUser {
+        username: username.to_owned(),
+        password: "password".to_owned(),
+        roles: Roles(vec![role.to_owned()]),
+        prefs: UserSettings::default(),
+        claimed_invite: invite,
+    }
+    .insert(&mut tx)
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+    user
+}
+
+async fn test_app() -> TestApp {
+    dim_database::set_key([7; 32]);
+
+    let root = std::env::temp_dir().join(format!("dim-security-boundary-{}", uuid::Uuid::new_v4()));
+    let metadata = root.join("metadata");
+    let cache = root.join("cache");
+    std::fs::create_dir_all(&metadata).unwrap();
+    std::fs::create_dir_all(&cache).unwrap();
+
+    let config_path = root.join("config.toml");
+    dim_core::settings::init_global_settings(Some(config_path.to_string_lossy().into_owned()))
+        .unwrap();
+    dim_core::core::METADATA_PATH
+        .set(metadata.to_string_lossy().into_owned())
+        .unwrap();
+
+    let db_path = root.join("dim.db");
+    let conn = dim_database::get_conn_file(db_path.to_str().unwrap())
+        .await
+        .unwrap();
+    let owner = insert_user(&conn, "owner", "owner").await;
+    let user = insert_user(&conn, "viewer", "user").await;
+
+    let owner_token = dim_database::user::Login::create_cookie(owner.id);
+    let user_token = dim_database::user::Login::create_cookie(user.id);
+
+    let (socket_tx, _socket_rx) = tokio::sync::mpsc::channel::<CtrlEvent<SocketAddr, String>>(16);
+    let (event_tx, _event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let state = nightfall::StateManager::new(
+        &mut Tokio::Global,
+        cache.to_string_lossy().into_owned(),
+        "/bin/false".to_owned(),
+    );
+    let app = AppState::new(conn, socket_tx, event_tx, state, StreamTracking::default());
+
+    TestApp {
+        router: build_router(app),
+        owner_token,
+        user_token,
+        root,
+    }
+}
+
+fn request(method: Method, uri: &str, token: Option<&str>, body: &str) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if let Some(token) = token {
+        builder = builder.header(AUTHORIZATION, token);
+    }
+    if !body.is_empty() {
+        builder = builder.header(CONTENT_TYPE, "application/json");
+    }
+    builder.body(Body::from(body.to_owned())).unwrap()
+}
+
+async fn response_body(response: axum::response::Response) -> Vec<u8> {
+    to_bytes(response.into_body()).await.unwrap().to_vec()
+}
+
+#[tokio::test]
+async fn enforces_the_application_security_boundary() {
+    let test = test_app().await;
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(Method::GET, "/api/v1/auth/admin_exists", None, ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    for uri in [
+        "/api/v1/library",
+        "/api/v1/auth/whoami",
+        "/api/v1/dashboard",
+        "/api/v1/search?query=movie",
+        "/api/v1/media/1/files",
+        "/api/v1/mediafile/1",
+        "/api/v1/season/1",
+        "/api/v1/user/settings",
+        "/api/v1/host/settings",
+        "/api/v1/auth/invites",
+        "/api/v1/filebrowser/tmp",
+        "/api/v1/stream/missing/state/get_stderr",
+    ] {
+        let response = test
+            .router
+            .clone()
+            .oneshot(request(Method::GET, uri, None, ""))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
+    }
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(
+            Method::GET,
+            "/api/v1/library",
+            Some(&test.user_token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(
+            Method::GET,
+            "/api/v1/user/settings",
+            Some(&test.user_token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    for (method, uri, body) in [
+        (Method::GET, "/api/v1/filebrowser/tmp", ""),
+        (Method::GET, "/api/v1/host/settings", ""),
+        (Method::POST, "/api/v1/host/settings", "{}"),
+        (Method::GET, "/api/v1/auth/invites", ""),
+        (Method::POST, "/api/v1/auth/invites", ""),
+        (Method::DELETE, "/api/v1/auth/token/invite", ""),
+        (Method::POST, "/api/v1/library", "{}"),
+        (Method::DELETE, "/api/v1/library/1", ""),
+        (Method::PATCH, "/api/v1/media/1", "{}"),
+        (Method::DELETE, "/api/v1/media/1", ""),
+        (Method::POST, "/api/v1/media/1/rematch", "{}"),
+        (Method::PATCH, "/api/v1/mediafile/match", "{}"),
+        (Method::PATCH, "/api/v1/season/1", "{}"),
+        (Method::DELETE, "/api/v1/season/1", ""),
+        (Method::PATCH, "/api/v1/episode/1", "{}"),
+        (Method::DELETE, "/api/v1/episode/1", ""),
+    ] {
+        let response = test
+            .router
+            .clone()
+            .oneshot(request(method, uri, Some(&test.user_token), body))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{uri}");
+    }
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(
+            Method::GET,
+            "/api/v1/filebrowser/tmp",
+            Some(&test.owner_token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(
+            Method::POST,
+            "/api/v1/auth/invites",
+            Some(&test.owner_token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(
+            Method::GET,
+            "/api/v1/host/settings",
+            Some(&test.owner_token),
+            "",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_body(response).await;
+    assert!(!String::from_utf8(body).unwrap().contains("secret_key"));
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(
+            Method::POST,
+            "/api/v1/host/settings",
+            Some(&test.owner_token),
+            r#"{"secret_key":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let mut malformed = request(Method::GET, "/api/v1/library", None, "");
+    malformed
+        .headers_mut()
+        .insert(AUTHORIZATION, HeaderValue::from_bytes(&[0xff]).unwrap());
+    let response = test.router.clone().oneshot(malformed).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(Method::GET, "/api/v1/library", Some(""), ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let metadata = test.root.join("metadata");
+    std::fs::write(metadata.join("poster.jpg"), b"poster").unwrap();
+    std::fs::write(test.root.join("outside.txt"), b"private").unwrap();
+
+    let response = test
+        .router
+        .clone()
+        .oneshot(request(Method::GET, "/images/poster.jpg", None, ""))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    for uri in [
+        "/images/../outside.txt",
+        "/images/%2e%2e/outside.txt",
+        "/images/%2Fetc%2Fpasswd",
+    ] {
+        let response = test
+            .router
+            .clone()
+            .oneshot(request(Method::GET, uri, None, ""))
+            .await
+            .unwrap();
+        assert_ne!(response.status(), StatusCode::OK, "{uri}");
+    }
+
+    let mut cors_request = request(Method::GET, "/api/v1/auth/admin_exists", None, "");
+    cors_request
+        .headers_mut()
+        .insert(ORIGIN, HeaderValue::from_static("https://example.com"));
+    let response = test.router.clone().oneshot(cors_request).await.unwrap();
+    assert!(response
+        .headers()
+        .get("access-control-allow-origin")
+        .is_none());
+
+    std::fs::remove_dir_all(&test.root).unwrap();
+}

--- a/ui/src/Pages/VideoPlayer/Events.jsx
+++ b/ui/src/Pages/VideoPlayer/Events.jsx
@@ -14,7 +14,8 @@ function VideoEvents() {
   const dispatch = useDispatch();
   const { player } = useContext(VideoPlayerContext);
 
-  const { video } = useSelector((store) => ({
+  const { token, video } = useSelector((store) => ({
+    token: store.auth.token,
     video: store.video,
   }));
 
@@ -118,7 +119,12 @@ function VideoEvents() {
 
       (async () => {
         console.log("[VIDEO] fetching stderr");
-        const res = await fetch(`/api/v1/stream/${video.gid}/state/get_stderr`);
+        const res = await fetch(
+          `/api/v1/stream/${video.gid}/state/get_stderr`,
+          {
+            headers: { Authorization: token },
+          }
+        );
         const error = await res.json();
 
         dispatch(
@@ -131,7 +137,7 @@ function VideoEvents() {
         );
       })();
     },
-    [dispatch, video.gid]
+    [dispatch, token, video.gid]
   );
 
   const ePlayBackNotAllowed = useCallback(

--- a/ui/src/Pages/VideoPlayer/Index.jsx
+++ b/ui/src/Pages/VideoPlayer/Index.jsx
@@ -226,7 +226,10 @@ function VideoPlayer() {
       if (!video.gid) return;
 
       (async () => {
-        await fetch(`/api/v1/stream/${video.gid}/state/kill`);
+        await fetch(`/api/v1/stream/${video.gid}/state/kill`, {
+          method: "DELETE",
+          headers: { Authorization: auth.token },
+        });
         sessionStorage.clear();
       })();
     };

--- a/ui/src/Pages/VideoPlayer/SsaSubtitles.jsx
+++ b/ui/src/Pages/VideoPlayer/SsaSubtitles.jsx
@@ -8,7 +8,8 @@ import JASSUB from "jassub";
 import "./Subtitles.scss";
 
 function VideoSubtitles() {
-  const { video, subtitle } = useSelector((store) => ({
+  const { token, video, subtitle } = useSelector((store) => ({
+    token: store.auth.token,
     video: store.video,
     subtitle: store.video.tracks.subtitle,
   }));
@@ -18,7 +19,39 @@ function VideoSubtitles() {
   const isAssEnabled = localStorage.getItem("enable_ssa") === "true";
   const isAss = !!(isAssEnabled && currentSub?.chunk_path?.endsWith("ass"));
   const [jassub, setJASSUB] = useState();
+  const [subContent, setSubContent] = useState();
   const { videoRef } = useContext(VideoPlayerContext);
+
+  useEffect(() => {
+    if (!isAss || !currentSub) {
+      setSubContent(null);
+      return;
+    }
+
+    let cancelled = false;
+    const chunkPath = `/api/v1/stream/${currentSub.chunk_path}`;
+    setSubContent(null);
+
+    (async () => {
+      try {
+        const response = await fetch(chunkPath, {
+          headers: { Authorization: token },
+        });
+
+        if (response.ok && !cancelled) {
+          setSubContent(await response.text());
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("[subtitle] failed to load ASS subtitle", error);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentSub, isAss, token]);
 
   useEffect(() => {
     if (
@@ -26,21 +59,18 @@ function VideoSubtitles() {
       !video.textTrackEnabled ||
       video.prevSubs === subtitle.current ||
       !isAss ||
+      !subContent ||
       !videoRef
     )
       return;
 
     console.log("[INFO] Loading ASS subtitle");
 
-    const chunk_path = `//${window.location.host}/api/v1/stream/${
-      subtitle.list[subtitle.current].chunk_path
-    }`;
-
     JASSUB._test();
 
     const options = {
       video: videoRef.current,
-      subUrl: chunk_path,
+      subContent,
       dropAllBlur: !JASSUB._supportsSIMD,
       workerUrl: new URL(
         "jassub/dist/jassub-worker.js",
@@ -64,22 +94,27 @@ function VideoSubtitles() {
       console.log("[subtitle] disposing of jassub ctx");
       if (jassub) jassub.destroy();
     };
-  }, [video, videoRef, subtitle, isAss, setJASSUB, jassub]);
+  }, [video, videoRef, subtitle, isAss, subContent, setJASSUB, jassub]);
 
   useEffect(() => {
     if (
       !jassub ||
       !video.textTrackEnabled ||
       video.prevSubs === subtitle.current ||
-      !isAss
+      !isAss ||
+      !subContent
     )
       return;
 
-    const chunk_path = `//${window.location.host}/api/v1/stream/${
-      subtitle.list[subtitle.current].chunk_path
-    }`;
-    jassub.setTrackByUrl(chunk_path);
-  }, [jassub, video.textTrackEnabled, video.prevSubs, subtitle, isAss]);
+    jassub.setTrack(subContent);
+  }, [
+    jassub,
+    video.textTrackEnabled,
+    video.prevSubs,
+    subtitle,
+    isAss,
+    subContent,
+  ]);
 
   useEffect(() => {
     if (jassub && !isAss) {

--- a/ui/src/Pages/VideoPlayer/VttSubtitles.jsx
+++ b/ui/src/Pages/VideoPlayer/VttSubtitles.jsx
@@ -11,7 +11,8 @@ import "./Subtitles.scss";
 function VideoSubtitles() {
   const dispatch = useDispatch();
 
-  const { video, current, tracks, ready } = useSelector((store) => ({
+  const { token, video, current, tracks, ready } = useSelector((store) => ({
+    token: store.auth.token,
     video: store.video,
     current: store.video.tracks.subtitle.current,
     tracks: store.video.tracks.subtitle.list,
@@ -112,7 +113,9 @@ function VideoSubtitles() {
     const intervalID = setInterval(async () => {
       const videoSubTrack = videoRef.current.textTracks[0];
 
-      const req = await fetch(`/api/v1/stream/${tracks[current].chunk_path}`);
+      const req = await fetch(`/api/v1/stream/${tracks[current].chunk_path}`, {
+        headers: { Authorization: token },
+      });
       const text = await req.text();
 
       const diff = text.split(prev).join("");
@@ -158,6 +161,7 @@ function VideoSubtitles() {
     video.textTrackEnabled,
     videoRef,
     isVtt,
+    token,
   ]);
 
   useEffect(() => {

--- a/ui/src/Routes/Private.jsx
+++ b/ui/src/Routes/Private.jsx
@@ -91,10 +91,13 @@ function PrivateRoute(props) {
     if (!GID) return;
 
     (async () => {
-      await fetch(`/api/v1/stream/${GID}/state/kill`);
+      await fetch(`/api/v1/stream/${GID}/state/kill`, {
+        method: "DELETE",
+        headers: { Authorization: token },
+      });
       sessionStorage.clear();
     })();
-  }, [history.location.pathname]);
+  }, [history.location.pathname, token]);
 
   useEffect(() => {
     dispatch(checkAdminExists());


### PR DESCRIPTION
- Enforces authentication across protected API and playback routes.
- Adds owner checks for administrative and destructive operations.
- Removes `secret_key` exposure from host settings.
- Constrains anonymous artwork access to Dim’s metadata directory.
- Handles malformed authentication without panics.
- Prevents unauthenticated WebSocket event delivery.
- Removes permissive CORS configuration.
- Adds authenticated frontend playback, subtitle, and stream-control requests.
- Restores functional user-settings routes.
- Adds integration tests for application security boundaries and re-enables CI tests.